### PR TITLE
Replace record binary with embedded POSIX shell script

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/swalha1999/lazycron/cron"
@@ -12,21 +11,14 @@ import (
 )
 
 func main() {
-	// If invoked as "record" (via symlink/copy), run record logic
-	base := filepath.Base(os.Args[0])
-	if base == "record" {
-		record.Run(os.Args[1:])
-		return
-	}
-
 	if err := cron.CheckCrontabAvailable(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
-	// Auto-install/update the record binary
+	// Auto-install/update the record script
 	if err := record.InstallRecord(); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not install record binary: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Warning: could not install record script: %v\n", err)
 	}
 
 	p := tea.NewProgram(

--- a/record/record.go
+++ b/record/record.go
@@ -1,14 +1,13 @@
 package record
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
+	_ "embed"
 	"os"
 	"path/filepath"
-	"strings"
-	"time"
 )
+
+//go:embed record.sh
+var ScriptContent []byte
 
 // Entry is the JSON structure written to history files.
 type Entry struct {
@@ -16,60 +15,6 @@ type Entry struct {
 	Timestamp string `json:"timestamp"`
 	Output    string `json:"output"`
 	Success   *bool  `json:"success,omitempty"`
-}
-
-// Run is the entrypoint when the binary is invoked as "record".
-// Usage: <command> | record "job-name" [exit-code]
-func Run(args []string) {
-	if len(args) < 1 {
-		fmt.Fprintln(os.Stderr, "usage: record <job-name> [exit-code]")
-		os.Exit(1)
-	}
-
-	jobName := args[0]
-	now := time.Now()
-
-	data, err := io.ReadAll(os.Stdin)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "record: reading stdin: %v\n", err)
-		os.Exit(1)
-	}
-
-	entry := Entry{
-		JobName:   jobName,
-		Timestamp: now.Format(time.RFC3339),
-		Output:    string(data),
-	}
-
-	// Parse optional exit code argument
-	if len(args) >= 2 {
-		success := args[1] == "0"
-		entry.Success = &success
-	}
-
-	histDir := HistoryDir()
-	if err := os.MkdirAll(histDir, 0o755); err != nil {
-		fmt.Fprintf(os.Stderr, "record: creating history dir: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Sanitize job name for filename
-	safeName := strings.ReplaceAll(jobName, "/", "_")
-	safeName = strings.ReplaceAll(safeName, " ", "_")
-
-	filename := fmt.Sprintf("%s_%s.json", now.Format("2006-01-02T15-04-05"), safeName)
-	path := filepath.Join(histDir, filename)
-
-	jsonData, err := json.MarshalIndent(entry, "", "  ")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "record: marshaling json: %v\n", err)
-		os.Exit(1)
-	}
-
-	if err := os.WriteFile(path, jsonData, 0o644); err != nil {
-		fmt.Fprintf(os.Stderr, "record: writing file: %v\n", err)
-		os.Exit(1)
-	}
 }
 
 // HistoryDir returns ~/.lazycron/history/
@@ -84,7 +29,7 @@ func BinDir() string {
 	return filepath.Join(home, ".lazycron", "bin")
 }
 
-// RecordPath returns the full path to the record binary.
+// RecordPath returns the full path to the record script.
 func RecordPath() string {
 	return filepath.Join(BinDir(), "record")
 }
@@ -97,30 +42,10 @@ func EnsureDirs() error {
 	return os.MkdirAll(HistoryDir(), 0o755)
 }
 
-// InstallRecord copies the current binary to ~/.lazycron/bin/record.
+// InstallRecord writes the embedded POSIX shell script to ~/.lazycron/bin/record.
 func InstallRecord() error {
 	if err := EnsureDirs(); err != nil {
 		return err
 	}
-
-	exePath, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("finding executable: %w", err)
-	}
-	exePath, err = filepath.EvalSymlinks(exePath)
-	if err != nil {
-		return fmt.Errorf("resolving symlinks: %w", err)
-	}
-
-	src, err := os.ReadFile(exePath)
-	if err != nil {
-		return fmt.Errorf("reading executable: %w", err)
-	}
-
-	dst := RecordPath()
-	if err := os.WriteFile(dst, src, 0o755); err != nil {
-		return fmt.Errorf("writing record binary: %w", err)
-	}
-
-	return nil
+	return os.WriteFile(RecordPath(), ScriptContent, 0o755)
 }

--- a/record/record.sh
+++ b/record/record.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# record — lazycron history recorder
+# Captures stdin and writes a JSON history entry.
+# Usage: <command> | record <job-name> [exit-code]
+
+if [ $# -lt 1 ]; then
+  echo "usage: record <job-name> [exit-code]" >&2
+  exit 1
+fi
+
+JOB="$1"
+EXIT="${2:-0}"
+OUTPUT="$(cat)"
+
+DIR="$HOME/.lazycron/history"
+mkdir -p "$DIR"
+
+STAMP="$(date +%Y-%m-%dT%H-%M-%S)"
+SAFE="$(printf '%s' "$JOB" | tr '/ ' '__')"
+
+if [ "$EXIT" = "0" ]; then
+  SUCCESS="true"
+else
+  SUCCESS="false"
+fi
+
+# JSON-escape: backslashes, quotes, carriage returns, tabs, then newlines
+json_escape() {
+  RS="$(printf '\036')"
+  printf '%s' "$1" | \
+    sed -e 's/\\/\\\\/g' \
+        -e 's/"/\\"/g' \
+        -e "s/$(printf '\r')/\\\\r/g" \
+        -e "s/$(printf '\t')/\\\\t/g" | \
+    tr '\n' "$RS" | \
+    sed "s/$RS/\\\\n/g"
+}
+
+ESC_JOB="$(json_escape "$JOB")"
+ESC_OUTPUT="$(json_escape "$OUTPUT")"
+
+{
+  printf '{\n'
+  printf '  "job_name": "'
+  printf '%s' "$ESC_JOB"
+  printf '",\n'
+  printf '  "timestamp": "%s",\n' "$(date +%Y-%m-%dT%H:%M:%S%z)"
+  printf '  "output": "'
+  printf '%s' "$ESC_OUTPUT"
+  printf '",\n'
+  printf '  "success": %s\n' "$SUCCESS"
+  printf '}\n'
+} > "$DIR/${STAMP}_${SAFE}.json"

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -1,0 +1,503 @@
+package record
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// runRecordScript executes the record shell script with the given input and arguments.
+// It sets HOME to a temp directory and returns the parsed entry and output file path.
+func runRecordScript(t *testing.T, input string, args ...string) (Entry, string) {
+	t.Helper()
+
+	home := t.TempDir()
+	scriptPath := filepath.Join(t.TempDir(), "record")
+
+	if err := os.WriteFile(scriptPath, ScriptContent, 0o755); err != nil {
+		t.Fatalf("writing script: %v", err)
+	}
+
+	cmd := exec.Command("sh", append([]string{scriptPath}, args...)...)
+	cmd.Stdin = strings.NewReader(input)
+	cmd.Env = []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("script failed: %v\noutput: %s", err, output)
+	}
+
+	histDir := filepath.Join(home, ".lazycron", "history")
+	files, err := filepath.Glob(filepath.Join(histDir, "*.json"))
+	if err != nil {
+		t.Fatalf("globbing: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 JSON file, got %d", len(files))
+	}
+
+	data, err := os.ReadFile(files[0])
+	if err != nil {
+		t.Fatalf("reading JSON: %v", err)
+	}
+
+	var entry Entry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("parsing JSON: %v\nraw: %s", err, data)
+	}
+
+	return entry, files[0]
+}
+
+// --- Basic functionality ---
+
+func TestScript_BasicSuccess(t *testing.T) {
+	entry, _ := runRecordScript(t, "hello world", "test-job", "0")
+
+	if entry.JobName != "test-job" {
+		t.Errorf("JobName = %q, want %q", entry.JobName, "test-job")
+	}
+	if entry.Output != "hello world" {
+		t.Errorf("Output = %q, want %q", entry.Output, "hello world")
+	}
+	if entry.Success == nil || *entry.Success != true {
+		t.Errorf("Success = %v, want true", entry.Success)
+	}
+}
+
+func TestScript_NonZeroExit(t *testing.T) {
+	entry, _ := runRecordScript(t, "error output", "fail-job", "1")
+
+	if entry.JobName != "fail-job" {
+		t.Errorf("JobName = %q, want %q", entry.JobName, "fail-job")
+	}
+	if entry.Output != "error output" {
+		t.Errorf("Output = %q, want %q", entry.Output, "error output")
+	}
+	if entry.Success == nil || *entry.Success != false {
+		t.Errorf("Success = %v, want false", entry.Success)
+	}
+}
+
+func TestScript_ExitCode127(t *testing.T) {
+	entry, _ := runRecordScript(t, "command not found", "missing-cmd", "127")
+
+	if entry.Success == nil || *entry.Success != false {
+		t.Errorf("Success = %v, want false (exit 127)", entry.Success)
+	}
+}
+
+func TestScript_DefaultExitCode(t *testing.T) {
+	entry, _ := runRecordScript(t, "output", "default-exit")
+
+	if entry.Success == nil || *entry.Success != true {
+		t.Errorf("Success = %v, want true (default exit 0)", entry.Success)
+	}
+}
+
+func TestScript_EmptyOutput(t *testing.T) {
+	entry, _ := runRecordScript(t, "", "empty-job", "0")
+
+	if entry.Output != "" {
+		t.Errorf("Output = %q, want empty", entry.Output)
+	}
+}
+
+// --- Multi-line output ---
+
+func TestScript_MultiLineOutput(t *testing.T) {
+	input := "line1\nline2\nline3"
+	entry, _ := runRecordScript(t, input, "multi-line", "0")
+
+	if entry.Output != input {
+		t.Errorf("Output = %q, want %q", entry.Output, input)
+	}
+}
+
+func TestScript_TrailingNewline(t *testing.T) {
+	// Command substitution strips trailing newlines, so "hello\n" becomes "hello"
+	entry, _ := runRecordScript(t, "hello\n", "trail-nl", "0")
+
+	if entry.Output != "hello" {
+		t.Errorf("Output = %q, want %q", entry.Output, "hello")
+	}
+}
+
+// --- Special character escaping ---
+
+func TestScript_OutputWithQuotes(t *testing.T) {
+	input := `he said "hello" and "goodbye"`
+	entry, _ := runRecordScript(t, input, "quotes-job", "0")
+
+	if entry.Output != input {
+		t.Errorf("Output = %q, want %q", entry.Output, input)
+	}
+}
+
+func TestScript_OutputWithBackslashes(t *testing.T) {
+	input := `path\to\file`
+	entry, _ := runRecordScript(t, input, "backslash-job", "0")
+
+	if entry.Output != input {
+		t.Errorf("Output = %q, want %q", entry.Output, input)
+	}
+}
+
+func TestScript_OutputWithTabs(t *testing.T) {
+	input := "col1\tcol2\tcol3"
+	entry, _ := runRecordScript(t, input, "tab-job", "0")
+
+	if entry.Output != input {
+		t.Errorf("Output = %q, want %q", entry.Output, input)
+	}
+}
+
+func TestScript_OutputWithDollarSign(t *testing.T) {
+	input := "price is $100 and $HOME is set"
+	entry, _ := runRecordScript(t, input, "dollar-job", "0")
+
+	if entry.Output != input {
+		t.Errorf("Output = %q, want %q", entry.Output, input)
+	}
+}
+
+func TestScript_OutputWithBackticks(t *testing.T) {
+	input := "result is `command` output"
+	entry, _ := runRecordScript(t, input, "backtick-job", "0")
+
+	if entry.Output != input {
+		t.Errorf("Output = %q, want %q", entry.Output, input)
+	}
+}
+
+func TestScript_OutputWithSingleQuotes(t *testing.T) {
+	input := "it's a test with 'quotes'"
+	entry, _ := runRecordScript(t, input, "single-quote-job", "0")
+
+	if entry.Output != input {
+		t.Errorf("Output = %q, want %q", entry.Output, input)
+	}
+}
+
+func TestScript_OutputWithBraces(t *testing.T) {
+	input := `{"key": "value", "arr": [1, 2, 3]}`
+	entry, _ := runRecordScript(t, input, "braces-job", "0")
+
+	if entry.Output != input {
+		t.Errorf("Output = %q, want %q", entry.Output, input)
+	}
+}
+
+func TestScript_OutputWithSymbols(t *testing.T) {
+	input := "!@#$%^&*()_+-=[]{}|;':,./<>?"
+	entry, _ := runRecordScript(t, input, "symbols-job", "0")
+
+	if entry.Output != input {
+		t.Errorf("Output = %q, want %q", entry.Output, input)
+	}
+}
+
+func TestScript_OutputWithMixedSpecialChars(t *testing.T) {
+	input := "line1: \"quoted\"\nline2: back\\slash\nline3: tab\there\nline4: $var and `cmd`"
+	entry, _ := runRecordScript(t, input, "mixed-job", "0")
+
+	if entry.Output != input {
+		t.Errorf("Output = %q, want %q", entry.Output, input)
+	}
+}
+
+func TestScript_OutputWithUnicode(t *testing.T) {
+	input := "unicode: caf\u00e9 r\u00e9sum\u00e9 \u2603 \u2764"
+	entry, _ := runRecordScript(t, input, "unicode-job", "0")
+
+	if entry.Output != input {
+		t.Errorf("Output = %q, want %q", entry.Output, input)
+	}
+}
+
+// --- Job name sanitization ---
+
+func TestScript_JobNameWithSlash(t *testing.T) {
+	entry, path := runRecordScript(t, "output", "path/to/job", "0")
+
+	if entry.JobName != "path/to/job" {
+		t.Errorf("JobName = %q, want %q", entry.JobName, "path/to/job")
+	}
+
+	filename := filepath.Base(path)
+	if strings.Contains(filename, "/") {
+		t.Errorf("filename should not contain /: %s", filename)
+	}
+	if !strings.Contains(filename, "path_to_job") {
+		t.Errorf("filename should sanitize slashes: %s", filename)
+	}
+}
+
+func TestScript_JobNameWithSpaces(t *testing.T) {
+	entry, path := runRecordScript(t, "output", "my job name", "0")
+
+	if entry.JobName != "my job name" {
+		t.Errorf("JobName = %q, want %q", entry.JobName, "my job name")
+	}
+
+	filename := filepath.Base(path)
+	if strings.Contains(filename, " ") {
+		t.Errorf("filename should not contain spaces: %s", filename)
+	}
+	if !strings.Contains(filename, "my_job_name") {
+		t.Errorf("filename should sanitize spaces: %s", filename)
+	}
+}
+
+// --- File and directory creation ---
+
+func TestScript_CreatesHistoryDir(t *testing.T) {
+	home := t.TempDir()
+	histDir := filepath.Join(home, ".lazycron", "history")
+
+	if _, err := os.Stat(histDir); !os.IsNotExist(err) {
+		t.Fatal("history dir should not exist yet")
+	}
+
+	scriptPath := filepath.Join(t.TempDir(), "record")
+	os.WriteFile(scriptPath, ScriptContent, 0o755)
+
+	cmd := exec.Command("sh", scriptPath, "dir-test", "0")
+	cmd.Stdin = strings.NewReader("hello")
+	cmd.Env = []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("script failed: %v", err)
+	}
+
+	if _, err := os.Stat(histDir); os.IsNotExist(err) {
+		t.Error("history dir was not created")
+	}
+}
+
+func TestScript_HistoryDirAlreadyExists(t *testing.T) {
+	home := t.TempDir()
+	histDir := filepath.Join(home, ".lazycron", "history")
+	os.MkdirAll(histDir, 0o755)
+
+	scriptPath := filepath.Join(t.TempDir(), "record")
+	os.WriteFile(scriptPath, ScriptContent, 0o755)
+
+	cmd := exec.Command("sh", scriptPath, "dir-test", "0")
+	cmd.Stdin = strings.NewReader("hello")
+	cmd.Env = []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("script should not fail when history dir exists: %v\n%s", err, output)
+	}
+
+	files, _ := filepath.Glob(filepath.Join(histDir, "*.json"))
+	if len(files) != 1 {
+		t.Fatalf("expected 1 JSON file, got %d", len(files))
+	}
+}
+
+func TestScript_FilenameFormat(t *testing.T) {
+	_, path := runRecordScript(t, "hello", "format-job", "0")
+
+	filename := filepath.Base(path)
+	if !strings.HasSuffix(filename, "_format-job.json") {
+		t.Errorf("unexpected filename suffix: %s", filename)
+	}
+	// Should start with YYYY-MM-DDTHH-MM-SS
+	if len(filename) < 20 {
+		t.Errorf("filename too short: %s", filename)
+	}
+	if filename[4] != '-' || filename[7] != '-' || filename[10] != 'T' {
+		t.Errorf("filename doesn't match date format: %s", filename)
+	}
+}
+
+// --- Timestamp ---
+
+func TestScript_TimestampPresent(t *testing.T) {
+	entry, _ := runRecordScript(t, "hello", "ts-job", "0")
+
+	if entry.Timestamp == "" {
+		t.Fatal("Timestamp is empty")
+	}
+	if len(entry.Timestamp) < 19 {
+		t.Errorf("Timestamp too short: %q", entry.Timestamp)
+	}
+	// Should start with YYYY-MM-DD
+	if entry.Timestamp[4] != '-' || entry.Timestamp[7] != '-' || entry.Timestamp[10] != 'T' {
+		t.Errorf("Timestamp doesn't match ISO format: %q", entry.Timestamp)
+	}
+}
+
+// --- JSON validity ---
+
+func TestScript_ValidJSON(t *testing.T) {
+	inputs := []struct {
+		name  string
+		input string
+	}{
+		{"empty", ""},
+		{"simple", "simple text"},
+		{"quotes", `with "quotes"`},
+		{"newlines", "with\nnewlines"},
+		{"tabs", "with\ttabs"},
+		{"backslashes", `with \backslashes\`},
+		{"mixed escapes", "mixed: \"\t\n\\"},
+		{"unicode", "caf\u00e9 r\u00e9sum\u00e9"},
+		{"symbols", "!@#$%^&*()"},
+		{"json-like", `{"key": [1,2,3]}`},
+		{"dollar signs", "$HOME $PATH $100"},
+		{"backticks", "`echo hi` `date`"},
+		{"single quotes", "it's a 'test'"},
+		{"angle brackets", "<html>&amp;</html>"},
+		{"percent signs", "100% done %s %d"},
+	}
+
+	for _, tt := range inputs {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			scriptPath := filepath.Join(t.TempDir(), "record")
+			os.WriteFile(scriptPath, ScriptContent, 0o755)
+
+			cmd := exec.Command("sh", scriptPath, "json-test", "0")
+			cmd.Stdin = strings.NewReader(tt.input)
+			cmd.Env = []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
+
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("script failed: %v\n%s", err, output)
+			}
+
+			files, _ := filepath.Glob(filepath.Join(home, ".lazycron", "history", "*.json"))
+			if len(files) != 1 {
+				t.Fatalf("expected 1 file, got %d", len(files))
+			}
+
+			data, _ := os.ReadFile(files[0])
+			var entry map[string]interface{}
+			if err := json.Unmarshal(data, &entry); err != nil {
+				t.Errorf("invalid JSON for input %q: %v\nraw: %s", tt.input, err, data)
+			}
+		})
+	}
+}
+
+// --- Error handling ---
+
+func TestScript_NoArgs(t *testing.T) {
+	scriptPath := filepath.Join(t.TempDir(), "record")
+	os.WriteFile(scriptPath, ScriptContent, 0o755)
+
+	cmd := exec.Command("sh", scriptPath)
+	cmd.Stdin = strings.NewReader("hello")
+	cmd.Env = []string{"HOME=" + t.TempDir(), "PATH=" + os.Getenv("PATH")}
+
+	err := cmd.Run()
+	if err == nil {
+		t.Error("expected script to fail with no args")
+	}
+}
+
+// --- Compatibility with Go history loader ---
+
+func TestScript_CompatibleWithGoEntry(t *testing.T) {
+	entry, _ := runRecordScript(t, "test output", "compat-job", "0")
+
+	// Verify all fields expected by history.LoadEntry / record.Entry
+	if entry.JobName == "" {
+		t.Error("JobName is empty")
+	}
+	if entry.Timestamp == "" {
+		t.Error("Timestamp is empty")
+	}
+	if entry.Success == nil {
+		t.Error("Success is nil")
+	}
+}
+
+// --- Multiple runs ---
+
+func TestScript_TwoRunsProduceTwoFiles(t *testing.T) {
+	home := t.TempDir()
+	scriptPath := filepath.Join(t.TempDir(), "record")
+	os.WriteFile(scriptPath, ScriptContent, 0o755)
+
+	env := []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
+
+	cmd1 := exec.Command("sh", scriptPath, "myjob", "0")
+	cmd1.Stdin = strings.NewReader("first")
+	cmd1.Env = env
+	if err := cmd1.Run(); err != nil {
+		t.Fatalf("first run failed: %v", err)
+	}
+
+	// Sleep 1 second so the timestamp-based filename differs
+	time.Sleep(1 * time.Second)
+
+	cmd2 := exec.Command("sh", scriptPath, "myjob", "0")
+	cmd2.Stdin = strings.NewReader("second")
+	cmd2.Env = env
+	if err := cmd2.Run(); err != nil {
+		t.Fatalf("second run failed: %v", err)
+	}
+
+	histDir := filepath.Join(home, ".lazycron", "history")
+	files, _ := filepath.Glob(filepath.Join(histDir, "*.json"))
+	if len(files) != 2 {
+		t.Errorf("expected 2 JSON files, got %d", len(files))
+	}
+}
+
+// --- InstallRecord ---
+
+func TestInstallRecord_WritesScript(t *testing.T) {
+	// Override HOME to a temp dir so we don't write to real ~/.lazycron
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := InstallRecord(); err != nil {
+		t.Fatalf("InstallRecord() error: %v", err)
+	}
+
+	path := filepath.Join(home, ".lazycron", "bin", "record")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading installed script: %v", err)
+	}
+
+	if !strings.HasPrefix(string(data), "#!/bin/sh") {
+		t.Error("installed file should start with #!/bin/sh shebang")
+	}
+
+	info, _ := os.Stat(path)
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Error("installed script should be executable")
+	}
+}
+
+func TestInstallRecord_Idempotent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := InstallRecord(); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if err := InstallRecord(); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+
+	path := filepath.Join(home, ".lazycron", "bin", "record")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading installed script: %v", err)
+	}
+	if string(data) != string(ScriptContent) {
+		t.Error("installed content should match embedded script")
+	}
+}

--- a/ui/bars.go
+++ b/ui/bars.go
@@ -57,8 +57,7 @@ func renderBottomBar(m mode, focusPanel int, statusMsg string, statusKind status
 	case modeHelp:
 		help = helpBinding("esc", "back")
 	case modeRunOutput:
-		help = helpBinding("j/k", "scroll") + helpSep() +
-			helpBinding("esc", "close")
+		help = helpBinding("esc", "close")
 	}
 
 	// Status message
@@ -183,7 +182,7 @@ func renderRunOutput(name, output string, failed bool, scroll, width, maxHeight 
 	}
 
 	b.WriteString("\n")
-	b.WriteString(mutedItemStyle.Render("  esc: close • j/k: scroll"))
+	b.WriteString(mutedItemStyle.Render("  esc: close"))
 
 	return formStyle.Width(boxWidth).Render(b.String())
 }


### PR DESCRIPTION
## Summary
- Replaces the Go-based `record` binary (self-copy of the lazycron executable) with a lightweight embedded POSIX shell script (`record.sh`)
- Removes the `record.Run()` Go entrypoint and the `filepath.Base` dispatch in `main.go`
- `InstallRecord()` now writes the embedded script via `//go:embed` instead of copying the full binary
- Adds comprehensive tests for the shell script (escaping, JSON validity, special characters, idempotency)
- Minor UI cleanup: removes stale j/k scroll bindings from run output view

Fixes #2

## Test plan
- [x] All 23 tests in `record/` pass
- [x] Project builds cleanly
- [ ] Manual: verify `lazycron` installs the shell script to `~/.lazycron/bin/record` on launch
- [ ] Manual: verify cron jobs using the record wrapper produce valid JSON history entries