### PR TITLE
Add one-shot job scheduling

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -20,6 +20,7 @@ var (
 	addCommand  string
 	addWorkDir  string
 	addDisabled bool
+	addOnce     bool
 )
 
 func init() {
@@ -28,6 +29,7 @@ func init() {
 	addCmd.Flags().StringVarP(&addCommand, "command", "c", "", "Command to run (required)")
 	addCmd.Flags().StringVarP(&addWorkDir, "workdir", "w", "", "Working directory (optional)")
 	addCmd.Flags().BoolVar(&addDisabled, "disabled", false, "Create the job in disabled state")
+	addCmd.Flags().BoolVar(&addOnce, "once", false, "Run once at the specified datetime and then disable")
 
 	addCmd.MarkFlagRequired("name")
 	addCmd.MarkFlagRequired("schedule")
@@ -41,9 +43,18 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cronExpr := cron.HumanToCron(addSchedule)
-	if err := cron.ValidateCron(cronExpr); err != nil {
-		return fmt.Errorf("invalid schedule %q: %w", addSchedule, err)
+	var cronExpr string
+	if addOnce {
+		expr, _, err := cron.DatetimeToCron(addSchedule)
+		if err != nil {
+			return fmt.Errorf("invalid datetime %q: %w", addSchedule, err)
+		}
+		cronExpr = expr
+	} else {
+		cronExpr = cron.HumanToCron(addSchedule)
+		if err := cron.ValidateCron(cronExpr); err != nil {
+			return fmt.Errorf("invalid schedule %q: %w", addSchedule, err)
+		}
 	}
 
 	finalCmd := addCommand
@@ -57,6 +68,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		Command:  finalCmd,
 		Enabled:  !addDisabled,
 		Wrapped:  true,
+		OneShot:  addOnce,
 	}
 
 	raw, err := cron.ReadCrontab()

--- a/cron/human.go
+++ b/cron/human.go
@@ -15,6 +15,21 @@ func CronToHuman(expr string) string {
 	}
 	min, hour, dom, mon, dow := parts[0], parts[1], parts[2], parts[3], parts[4]
 
+	// Detect one-shot-style expression: all 4 date fields are specific values
+	if isValue(min) && isValue(hour) && isValue(dom) && isValue(mon) && dow == "*" {
+		h, _ := strconv.Atoi(hour)
+		m, _ := strconv.Atoi(min)
+		d, _ := strconv.Atoi(dom)
+		mo, _ := strconv.Atoi(mon)
+		now := time.Now()
+		year := now.Year()
+		t := time.Date(year, time.Month(mo), d, h, m, 0, 0, time.Local)
+		if t.Before(now) {
+			t = time.Date(year+1, time.Month(mo), d, h, m, 0, 0, time.Local)
+		}
+		return t.Format("Jan 02, 2006 at 3:04 PM")
+	}
+
 	// Build the frequency part (how often within a day): minute + hour
 	freq := describeFrequency(min, hour)
 

--- a/cron/parser.go
+++ b/cron/parser.go
@@ -16,6 +16,7 @@ type Job struct {
 	Wrapped  bool   // true if the raw command uses the current record wrapper format
 	Tag      string // optional colored tag displayed after the name
 	TagColor string // hex color for the tag, e.g. "#f38ba8"
+	OneShot  bool   // true if this job should run once and then self-disable
 }
 
 // recordBinPath returns the path to ~/.lazycron/bin/record.
@@ -34,6 +35,13 @@ const wrapEndMarker = `; } 2>&1); __lc_ec=$?;`
 // and piped through the record binary for history tracking.
 func WrapWithRecord(command, jobName string) string {
 	return fmt.Sprintf(`%s%s%s echo "$__lc_out" | %s %q "$__lc_ec"`,
+		wrapPrefix, command, wrapEndMarker, recordBinPath(), jobName)
+}
+
+// WrapWithRecordOnce wraps a command like WrapWithRecord but appends --once
+// so the record script auto-disables the crontab entry after execution.
+func WrapWithRecordOnce(command, jobName string) string {
+	return fmt.Sprintf(`%s%s%s echo "$__lc_out" | %s %q "$__lc_ec" --once`,
 		wrapPrefix, command, wrapEndMarker, recordBinPath(), jobName)
 }
 
@@ -81,6 +89,9 @@ func IsCurrentFormat(rawCommand string) bool {
 func (j Job) CrontabLine() string {
 	var b strings.Builder
 	nameComment := j.Name
+	if j.OneShot {
+		nameComment += " @once"
+	}
 	if j.Tag != "" {
 		color := j.TagColor
 		if color == "" {
@@ -90,7 +101,12 @@ func (j Job) CrontabLine() string {
 	}
 	fmt.Fprintf(&b, "# %s\n", nameComment)
 
-	wrapped := WrapWithRecord(j.Command, j.Name)
+	var wrapped string
+	if j.OneShot {
+		wrapped = WrapWithRecordOnce(j.Command, j.Name)
+	} else {
+		wrapped = WrapWithRecord(j.Command, j.Name)
+	}
 	if !j.Enabled {
 		fmt.Fprintf(&b, "#DISABLED %s %s", j.Schedule, wrapped)
 	} else {
@@ -118,6 +134,8 @@ func Parse(output string) []Job {
 		// Check if this is a name comment: # job-name [TAG:color]
 		if isNameComment(line) {
 			name := strings.TrimSpace(strings.TrimPrefix(line, "#"))
+			var oneShot bool
+			name, oneShot = extractOnce(name)
 			tag, tagColor := "", ""
 			name, tag, tagColor = extractTag(name)
 			i++
@@ -130,6 +148,7 @@ func Parse(output string) []Job {
 				if job, ok := parseJobLine(jobLine, name); ok {
 					job.Tag = tag
 					job.TagColor = tagColor
+					job.OneShot = oneShot
 					jobs = append(jobs, job)
 					i++
 					continue
@@ -150,6 +169,22 @@ func Parse(output string) []Job {
 	}
 
 	return jobs
+}
+
+// extractOnce checks for the @once marker in a name comment.
+// Returns the clean name (without @once) and whether it was present.
+func extractOnce(name string) (string, bool) {
+	const marker = " @once"
+	if idx := strings.Index(name, marker); idx != -1 {
+		// Ensure @once is followed by nothing, whitespace, or [
+		after := name[idx+len(marker):]
+		after = strings.TrimSpace(after)
+		if after == "" || strings.HasPrefix(after, "[") {
+			clean := strings.TrimSpace(name[:idx] + " " + after)
+			return clean, true
+		}
+	}
+	return name, false
 }
 
 // extractTag parses a tag suffix from a name like "Job Name [PP:#f38ba8]".

--- a/cron/parser_test.go
+++ b/cron/parser_test.go
@@ -410,6 +410,107 @@ func TestFullRoundtrip_Disabled(t *testing.T) {
 	assertBool(t, "Wrapped", got.Wrapped, true)
 }
 
+// --- extractOnce ---
+
+func TestExtractOnce(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantName string
+		wantOnce bool
+	}{
+		{"with @once", "My Job @once", "My Job", true},
+		{"with @once and tag", "My Job @once [TAG:#f38ba8]", "My Job [TAG:#f38ba8]", true},
+		{"no @once", "My Job", "My Job", false},
+		{"no @once with tag", "My Job [TAG:#f38ba8]", "My Job [TAG:#f38ba8]", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotOnce := extractOnce(tt.input)
+			if gotName != tt.wantName {
+				t.Errorf("extractOnce(%q) name = %q, want %q", tt.input, gotName, tt.wantName)
+			}
+			if gotOnce != tt.wantOnce {
+				t.Errorf("extractOnce(%q) once = %v, want %v", tt.input, gotOnce, tt.wantOnce)
+			}
+		})
+	}
+}
+
+// --- Parse with @once ---
+
+func TestParse_OneShotJob(t *testing.T) {
+	input := "# deploy @once\n30 14 22 3 * " + wrapCmd("echo deploy", "deploy")
+	jobs := Parse(input)
+
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	j := jobs[0]
+	assertEqual(t, "Name", j.Name, "deploy")
+	assertBool(t, "OneShot", j.OneShot, true)
+	assertEqual(t, "Schedule", j.Schedule, "30 14 22 3 *")
+}
+
+func TestParse_OneShotJobWithTag(t *testing.T) {
+	input := "# deploy @once [PROD:#f38ba8]\n30 14 22 3 * " + wrapCmd("echo deploy", "deploy")
+	jobs := Parse(input)
+
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	j := jobs[0]
+	assertEqual(t, "Name", j.Name, "deploy")
+	assertBool(t, "OneShot", j.OneShot, true)
+	assertEqual(t, "Tag", j.Tag, "PROD")
+	assertEqual(t, "TagColor", j.TagColor, "#f38ba8")
+}
+
+func TestCrontabLine_OneShot(t *testing.T) {
+	j := Job{Name: "deploy", Schedule: "30 14 22 3 *", Command: "echo deploy", Enabled: true, Wrapped: true, OneShot: true}
+	line := j.CrontabLine()
+
+	if !strings.HasPrefix(line, "# deploy @once\n") {
+		t.Errorf("expected @once in name comment: %q", line)
+	}
+	if !strings.Contains(line, "--once") {
+		t.Errorf("expected --once in wrapped command: %q", line)
+	}
+}
+
+func TestCrontabLine_OneShotWithTag(t *testing.T) {
+	j := Job{Name: "deploy", Schedule: "30 14 22 3 *", Command: "echo deploy", Enabled: true, Wrapped: true, OneShot: true, Tag: "PROD", TagColor: "#f38ba8"}
+	line := j.CrontabLine()
+
+	if !strings.Contains(line, "# deploy @once [PROD:#f38ba8]") {
+		t.Errorf("expected @once before tag: %q", line)
+	}
+}
+
+func TestFullRoundtrip_OneShot(t *testing.T) {
+	original := Job{
+		Name:     "one-shot-test",
+		Schedule: "30 14 22 3 *",
+		Command:  "echo hello",
+		Enabled:  true,
+		Wrapped:  true,
+		OneShot:  true,
+	}
+
+	line := original.CrontabLine()
+	jobs := Parse(line)
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job after roundtrip, got %d", len(jobs))
+	}
+
+	got := jobs[0]
+	assertEqual(t, "Name", got.Name, original.Name)
+	assertEqual(t, "Schedule", got.Schedule, original.Schedule)
+	assertEqual(t, "Command", got.Command, original.Command)
+	assertBool(t, "Enabled", got.Enabled, original.Enabled)
+	assertBool(t, "OneShot", got.OneShot, true)
+}
+
 // --- helpers ---
 
 func assertEqual(t *testing.T, field, got, want string) {

--- a/cron/schedule.go
+++ b/cron/schedule.go
@@ -103,6 +103,112 @@ func parseTime(s string) (hour, minute int, ok bool) {
 	return 0, 0, false
 }
 
+// DatetimeToCron converts a datetime string to a pinned cron expression.
+// Supports strict formats: "2026-03-22 14:30", "2026-03-22T14:30"
+// and natural language: "tomorrow at 3pm", "next monday at 9am", "march 22 at 2:30pm"
+// Returns the cron expression, the resolved time, and any error.
+func DatetimeToCron(input string) (string, time.Time, error) {
+	s := strings.TrimSpace(input)
+	now := time.Now()
+
+	var resolved time.Time
+	var ok bool
+
+	// Try strict ISO-like formats first
+	for _, layout := range []string{
+		"2006-01-02 15:04",
+		"2006-01-02T15:04",
+	} {
+		if t, err := time.ParseInLocation(layout, s, time.Local); err == nil {
+			resolved = t
+			ok = true
+			break
+		}
+	}
+
+	// Try natural language
+	if !ok {
+		resolved, ok = parseNaturalDatetime(s, now)
+	}
+
+	if !ok {
+		return "", time.Time{}, fmt.Errorf("could not parse datetime %q — try 'tomorrow at 3pm' or '2026-03-22 14:30'", input)
+	}
+
+	if !resolved.After(now) {
+		return "", time.Time{}, fmt.Errorf("scheduled time %s is in the past", resolved.Format("2006-01-02 15:04"))
+	}
+
+	cronExpr := fmt.Sprintf("%d %d %d %d *", resolved.Minute(), resolved.Hour(), resolved.Day(), int(resolved.Month()))
+	return cronExpr, resolved, nil
+}
+
+// parseNaturalDatetime parses natural language datetime relative to now.
+func parseNaturalDatetime(s string, now time.Time) (time.Time, bool) {
+	lower := strings.ToLower(s)
+
+	// "tomorrow at <time>"
+	if m := regexp.MustCompile(`^tomorrow at (.+)$`).FindStringSubmatch(lower); m != nil {
+		if h, mi, ok := parseTime(m[1]); ok {
+			tomorrow := now.AddDate(0, 0, 1)
+			return time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), h, mi, 0, 0, time.Local), true
+		}
+	}
+
+	// "next <dayname> at <time>"
+	if m := regexp.MustCompile(`^next (\w+) at (.+)$`).FindStringSubmatch(lower); m != nil {
+		if dow, ok := dayMap[m[1]]; ok {
+			if h, mi, ok := parseTime(m[2]); ok {
+				target, _ := strconv.Atoi(dow)
+				current := int(now.Weekday())
+				daysAhead := (target - current + 7) % 7
+				if daysAhead == 0 {
+					daysAhead = 7 // "next Monday" when today is Monday means 7 days
+				}
+				d := now.AddDate(0, 0, daysAhead)
+				return time.Date(d.Year(), d.Month(), d.Day(), h, mi, 0, 0, time.Local), true
+			}
+		}
+	}
+
+	// "<monthname> <day> at <time>" e.g. "march 22 at 2:30pm"
+	if m := regexp.MustCompile(`^(\w+) (\d{1,2}) at (.+)$`).FindStringSubmatch(lower); m != nil {
+		if month, ok := parseMonth(m[1]); ok {
+			day, _ := strconv.Atoi(m[2])
+			if h, mi, ok := parseTime(m[3]); ok {
+				year := now.Year()
+				t := time.Date(year, month, day, h, mi, 0, 0, time.Local)
+				if !t.After(now) {
+					t = time.Date(year+1, month, day, h, mi, 0, 0, time.Local)
+				}
+				return t, true
+			}
+		}
+	}
+
+	return time.Time{}, false
+}
+
+// parseMonth converts a month name to time.Month.
+func parseMonth(s string) (time.Month, bool) {
+	months := map[string]time.Month{
+		"january": time.January, "jan": time.January,
+		"february": time.February, "feb": time.February,
+		"march": time.March, "mar": time.March,
+		"april": time.April, "apr": time.April,
+		"may": time.May,
+		"june": time.June, "jun": time.June,
+		"july": time.July, "jul": time.July,
+		"august": time.August, "aug": time.August,
+		"september": time.September, "sep": time.September,
+		"october": time.October, "oct": time.October,
+		"november": time.November, "nov": time.November,
+		"december": time.December, "dec": time.December,
+	}
+	m, ok := months[strings.ToLower(s)]
+	return m, ok
+}
+
 // NextRuns computes the next n run times for a cron expression.
 func NextRuns(expr string, n int) []time.Time {
 	parts := strings.Fields(expr)

--- a/cron/schedule_test.go
+++ b/cron/schedule_test.go
@@ -304,3 +304,103 @@ func TestNextRuns_ZeroCount(t *testing.T) {
 		t.Errorf("NextRuns with 0 count returned %d results", len(results))
 	}
 }
+
+// --- DatetimeToCron ---
+
+func TestDatetimeToCron_StrictFormats(t *testing.T) {
+	// Use a future date
+	future := time.Now().AddDate(1, 0, 0)
+	dateStr := future.Format("2006-01-02") + " 14:30"
+
+	expr, resolved, err := DatetimeToCron(dateStr)
+	if err != nil {
+		t.Fatalf("DatetimeToCron(%q) error: %v", dateStr, err)
+	}
+	if resolved.Hour() != 14 || resolved.Minute() != 30 {
+		t.Errorf("resolved time = %v, want 14:30", resolved)
+	}
+	expected := "30 14 " + future.Format("2") + " " + future.Format("1") + " *"
+	if expr != expected {
+		t.Errorf("DatetimeToCron = %q, want %q", expr, expected)
+	}
+}
+
+func TestDatetimeToCron_ISOFormat(t *testing.T) {
+	future := time.Now().AddDate(1, 0, 0)
+	dateStr := future.Format("2006-01-02") + "T09:00"
+
+	expr, _, err := DatetimeToCron(dateStr)
+	if err != nil {
+		t.Fatalf("DatetimeToCron(%q) error: %v", dateStr, err)
+	}
+	expected := "0 9 " + future.Format("2") + " " + future.Format("1") + " *"
+	if expr != expected {
+		t.Errorf("DatetimeToCron = %q, want %q", expr, expected)
+	}
+}
+
+func TestDatetimeToCron_TomorrowAt(t *testing.T) {
+	expr, resolved, err := DatetimeToCron("tomorrow at 3pm")
+	if err != nil {
+		t.Fatalf("DatetimeToCron('tomorrow at 3pm') error: %v", err)
+	}
+
+	tomorrow := time.Now().AddDate(0, 0, 1)
+	if resolved.Day() != tomorrow.Day() {
+		t.Errorf("resolved day = %d, want %d", resolved.Day(), tomorrow.Day())
+	}
+	if resolved.Hour() != 15 || resolved.Minute() != 0 {
+		t.Errorf("resolved time = %d:%d, want 15:00", resolved.Hour(), resolved.Minute())
+	}
+
+	expected := "0 15 " + tomorrow.Format("2") + " " + tomorrow.Format("1") + " *"
+	if expr != expected {
+		t.Errorf("DatetimeToCron = %q, want %q", expr, expected)
+	}
+}
+
+func TestDatetimeToCron_NextDayAt(t *testing.T) {
+	_, resolved, err := DatetimeToCron("next monday at 9am")
+	if err != nil {
+		t.Fatalf("DatetimeToCron('next monday at 9am') error: %v", err)
+	}
+	if resolved.Weekday() != time.Monday {
+		t.Errorf("resolved weekday = %v, want Monday", resolved.Weekday())
+	}
+	if resolved.Hour() != 9 || resolved.Minute() != 0 {
+		t.Errorf("resolved time = %d:%d, want 9:00", resolved.Hour(), resolved.Minute())
+	}
+}
+
+func TestDatetimeToCron_PastTimeError(t *testing.T) {
+	past := time.Now().AddDate(-1, 0, 0)
+	dateStr := past.Format("2006-01-02") + " 14:30"
+
+	_, _, err := DatetimeToCron(dateStr)
+	if err == nil {
+		t.Error("DatetimeToCron should return error for past time")
+	}
+}
+
+func TestDatetimeToCron_InvalidInput(t *testing.T) {
+	_, _, err := DatetimeToCron("not a date")
+	if err == nil {
+		t.Error("DatetimeToCron should return error for invalid input")
+	}
+}
+
+func TestDatetimeToCron_MonthDayAt(t *testing.T) {
+	// Use a month that's far in the future to ensure it's not in the past
+	future := time.Now().AddDate(1, 0, 0)
+	monthName := future.Format("January")
+	dayStr := future.Format("2")
+	input := monthName + " " + dayStr + " at 2:30pm"
+
+	_, resolved, err := DatetimeToCron(input)
+	if err != nil {
+		t.Fatalf("DatetimeToCron(%q) error: %v", input, err)
+	}
+	if resolved.Hour() != 14 || resolved.Minute() != 30 {
+		t.Errorf("resolved time = %d:%d, want 14:30", resolved.Hour(), resolved.Minute())
+	}
+}

--- a/record/record.sh
+++ b/record/record.sh
@@ -54,3 +54,9 @@ ESC_OUTPUT="$(json_escape "$OUTPUT")"
   printf '  "success": %s\n' "$SUCCESS"
   printf '}\n'
 } > "$DIR/${STAMP}_${SAFE}.json"
+
+# One-shot jobs: disable the crontab entry after execution
+if [ "$3" = "--once" ]; then
+  SAFE_NAME="$(printf '%s' "$JOB" | sed 's/[.*[\^$]/\\&/g')"
+  crontab -l 2>/dev/null | sed "/^# ${SAFE_NAME}/{ n; s/^/#DISABLED /; }" | crontab -
+fi

--- a/ui/detail.go
+++ b/ui/detail.go
@@ -25,6 +25,16 @@ func renderDetail(job *cron.Job, width int) string {
 	b.WriteString(renderDetailRow("Status", status))
 	b.WriteString("\n")
 
+	// Type
+	if job.OneShot {
+		typeStr := lipgloss.NewStyle().Foreground(colorYellow).Bold(true).Render("One-shot")
+		if !job.Enabled {
+			typeStr += " " + mutedItemStyle.Render("(completed)")
+		}
+		b.WriteString(renderDetailRow("Type", typeStr))
+		b.WriteString("\n")
+	}
+
 	// Name (with optional colored tag)
 	nameDisplay := detailValueStyle.Render(job.Name)
 	if job.Tag != "" {
@@ -66,18 +76,36 @@ func renderDetail(job *cron.Job, width int) string {
 
 	// Next runs
 	b.WriteString("\n")
-	b.WriteString(detailHeaderStyle.Render("  Next Runs"))
-	b.WriteString("\n")
-	nextRuns := cron.NextRuns(job.Schedule, 3)
-	if len(nextRuns) == 0 {
-		b.WriteString("  " + mutedItemStyle.Render("Could not calculate") + "\n")
+	if job.OneShot {
+		if !job.Enabled {
+			b.WriteString(detailHeaderStyle.Render("  Completed"))
+			b.WriteString("\n")
+			b.WriteString("  " + mutedItemStyle.Render("This one-shot job has been executed") + "\n")
+		} else {
+			b.WriteString(detailHeaderStyle.Render("  Scheduled For"))
+			b.WriteString("\n")
+			nextRuns := cron.NextRuns(job.Schedule, 1)
+			if len(nextRuns) == 0 {
+				b.WriteString("  " + mutedItemStyle.Render("Could not calculate") + "\n")
+			} else {
+				timeStr := nextRuns[0].Format("Mon Jan 02, 2006 at 3:04 PM")
+				b.WriteString("  " + detailValueStyle.Render(timeStr) + "\n")
+			}
+		}
 	} else {
-		for i, t := range nextRuns {
-			timeStr := t.Format("Mon Jan 02, 2006 at 3:04 PM")
-			b.WriteString(fmt.Sprintf("  %s %s\n",
-				mutedItemStyle.Render(fmt.Sprintf("%d.", i+1)),
-				detailValueStyle.Render(timeStr),
-			))
+		b.WriteString(detailHeaderStyle.Render("  Next Runs"))
+		b.WriteString("\n")
+		nextRuns := cron.NextRuns(job.Schedule, 3)
+		if len(nextRuns) == 0 {
+			b.WriteString("  " + mutedItemStyle.Render("Could not calculate") + "\n")
+		} else {
+			for i, t := range nextRuns {
+				timeStr := t.Format("Mon Jan 02, 2006 at 3:04 PM")
+				b.WriteString(fmt.Sprintf("  %s %s\n",
+					mutedItemStyle.Render(fmt.Sprintf("%d.", i+1)),
+					detailValueStyle.Render(timeStr),
+				))
+			}
 		}
 	}
 

--- a/ui/form.go
+++ b/ui/form.go
@@ -41,6 +41,7 @@ type formModel struct {
 	completer   completerModel
 	tag         string // colored tag from template
 	tagColor    string // hex color for the tag
+	oneShot     bool   // one-shot mode: run once at a specific datetime
 }
 
 func newInput(i int) textinput.Model {
@@ -89,9 +90,12 @@ func newFormForEdit(job cron.Job, index int) formModel {
 	f.inputs[fieldWorkDir].SetValue(workDir)
 	f.tag = job.Tag
 	f.tagColor = job.TagColor
+	f.oneShot = job.OneShot
 
 	f.picker = newPicker()
-	f.picker.ParseExpression(job.Schedule)
+	if !f.oneShot {
+		f.picker.ParseExpression(job.Schedule)
+	}
 
 	return f
 }
@@ -106,8 +110,8 @@ func (f *formModel) focusActive() tea.Cmd {
 }
 
 func (f *formModel) nextField() tea.Cmd {
-	// If on schedule textinput, tab into picker
-	if f.activeField == fieldSchedule && !f.picker.focused {
+	// If on schedule textinput and not one-shot, tab into picker
+	if f.activeField == fieldSchedule && !f.picker.focused && !f.oneShot {
 		f.inputs[fieldSchedule].Blur()
 		f.syncInputToPicker()
 		f.picker.focused = true
@@ -131,7 +135,7 @@ func (f *formModel) prevField() tea.Cmd {
 	f.inputs[f.activeField].Blur()
 	f.completer.reset()
 	prev := (f.activeField - 1 + fieldCount) % fieldCount
-	if prev == fieldSchedule {
+	if prev == fieldSchedule && !f.oneShot {
 		f.activeField = fieldSchedule
 		f.syncInputToPicker()
 		f.picker.focused = true
@@ -174,9 +178,18 @@ func (f *formModel) buildJob() (cron.Job, error) {
 		return cron.Job{}, fmt.Errorf("schedule is required")
 	}
 
-	cronExpr := cron.HumanToCron(schedule)
-	if err := cron.ValidateCron(cronExpr); err != nil {
-		return cron.Job{}, fmt.Errorf("invalid schedule: %w", err)
+	var cronExpr string
+	if f.oneShot {
+		expr, _, err := cron.DatetimeToCron(schedule)
+		if err != nil {
+			return cron.Job{}, fmt.Errorf("invalid datetime: %w", err)
+		}
+		cronExpr = expr
+	} else {
+		cronExpr = cron.HumanToCron(schedule)
+		if err := cron.ValidateCron(cronExpr); err != nil {
+			return cron.Job{}, fmt.Errorf("invalid schedule: %w", err)
+		}
 	}
 
 	finalCmd := command
@@ -192,6 +205,7 @@ func (f *formModel) buildJob() (cron.Job, error) {
 		Wrapped:  true,
 		Tag:      f.tag,
 		TagColor: f.tagColor,
+		OneShot:  f.oneShot,
 	}, nil
 }
 
@@ -213,10 +227,23 @@ func renderForm(f *formModel, width int) string {
 
 	var b strings.Builder
 	b.WriteString(formTitleStyle.Render("  " + title))
+	b.WriteString("  ")
+	if f.oneShot {
+		b.WriteString(lipgloss.NewStyle().Foreground(colorYellow).Bold(true).Render("ONE-SHOT"))
+	} else {
+		b.WriteString(mutedItemStyle.Render("recurring"))
+	}
 	b.WriteString("\n\n")
 
 	for i := 0; i < fieldCount; i++ {
 		label := formLabelStyle.Render(fmt.Sprintf("  %-10s", fieldLabels[i]+":"))
+
+		// Override schedule placeholder in one-shot mode
+		if i == fieldSchedule && f.oneShot {
+			f.inputs[i].Placeholder = "Date/time: 'tomorrow at 3pm' or '2026-03-22 14:30'"
+		} else if i == fieldSchedule {
+			f.inputs[i].Placeholder = fieldHints[fieldSchedule]
+		}
 
 		f.inputs[i].Width = inputWidth
 		rendered := lipgloss.NewStyle().
@@ -227,7 +254,7 @@ func renderForm(f *formModel, width int) string {
 		b.WriteString(label + " " + rendered)
 		b.WriteString("\n")
 
-		if i == fieldSchedule {
+		if i == fieldSchedule && !f.oneShot {
 			b.WriteString(renderPicker(&f.picker, inputWidth))
 			b.WriteString("\n")
 		}
@@ -257,6 +284,7 @@ func renderForm(f *formModel, width int) string {
 		b.WriteString("  " +
 			helpBinding("tab", "next field") + helpSep() +
 			helpBinding("shift+tab", "prev") + helpSep() +
+			helpBinding("ctrl+o", "one-shot") + helpSep() +
 			helpBinding("enter", "save") + helpSep() +
 			helpBinding("esc", "cancel"))
 	}

--- a/ui/joblist.go
+++ b/ui/joblist.go
@@ -87,13 +87,19 @@ func renderJobList(jobs []cron.Job, selected int, width, height int) string {
 			cmd = cmd[:cmdWidth-1] + "…"
 		}
 
+		// One-shot badge
+		onceBadge := ""
+		if job.OneShot {
+			onceBadge = " " + lipgloss.NewStyle().Foreground(colorYellow).Bold(true).Render("ONCE")
+		}
+
 		// Warning indicator for jobs not using the current record format
 		warn := ""
 		if !job.Wrapped {
 			warn = " " + warnStyle.Render("⚠")
 		}
 
-		line := fmt.Sprintf(" %s %-*s%s  %s%s", dot, maxNameWidth, name, tagSuffix, mutedItemStyle.Render(schedule), warn)
+		line := fmt.Sprintf(" %s %-*s%s%s  %s%s", dot, maxNameWidth, name, tagSuffix, onceBadge, mutedItemStyle.Render(schedule), warn)
 
 		if i == selected {
 			line = selectedStyle.Render("▶ " + line)

--- a/ui/update.go
+++ b/ui/update.go
@@ -709,6 +709,17 @@ func (m Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	switch key {
+	case "ctrl+o":
+		m.form.oneShot = !m.form.oneShot
+		if m.form.oneShot {
+			// Clear schedule field for fresh datetime input
+			m.form.inputs[fieldSchedule].SetValue("")
+			m.form.picker.focused = false
+		} else {
+			m.form.inputs[fieldSchedule].SetValue(m.form.picker.Expression())
+		}
+		return m, nil
+
 	case "esc":
 		m.mode = modeNormal
 		m.statusMsg = "Cancelled"


### PR DESCRIPTION
## Summary
- Schedule commands to run once at a specific datetime (e.g. "tomorrow at 3pm", "2026-03-22 14:30")
- Jobs are stored as pinned cron expressions with `@once` marker and auto-disable via `#DISABLED` after execution
- Toggle one-shot mode in the form UI with `ctrl+o`, or use `--once` flag with `lazycron add`

## Changes
- **cron/parser.go**: `OneShot` field on `Job`, `@once` marker in name comments, `WrapWithRecordOnce` wrapper
- **cron/schedule.go**: `DatetimeToCron()` — strict ISO + natural language datetime parsing
- **cron/human.go**: `CronToHuman` renders pinned date expressions as readable dates
- **record/record.sh**: `--once` flag triggers crontab self-disable after recording
- **ui/form.go + ui/update.go**: `ctrl+o` toggles one-shot mode, hides cron picker, shows datetime placeholder
- **ui/joblist.go**: Yellow `ONCE` badge for one-shot jobs
- **ui/detail.go**: "Type: One-shot", "Scheduled For" instead of "Next Runs", "Completed" for disabled one-shot jobs
- **cmd/add.go**: `--once` CLI flag

## Test plan
- [x] `go build` compiles
- [x] `go vet` clean
- [x] `go test ./cron/...` — all pass (13 new tests for parser roundtrips + DatetimeToCron)
- [ ] Manual: create one-shot job via form (`ctrl+o`), verify crontab has `@once` and `--once`
- [ ] Manual: verify `ONCE` badge in job list and "Scheduled For" in detail panel
- [ ] Manual: let a one-shot fire, verify it self-disables and history is recorded