### PR TITLE
Add project grouping for jobs with collapsible sections

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -19,6 +19,7 @@ var (
 	addSchedule string
 	addCommand  string
 	addWorkDir  string
+	addProject  string
 	addDisabled bool
 	addOnce     bool
 )
@@ -28,6 +29,7 @@ func init() {
 	addCmd.Flags().StringVarP(&addSchedule, "schedule", "s", "", "Cron schedule or human-readable (required)")
 	addCmd.Flags().StringVarP(&addCommand, "command", "c", "", "Command to run (required)")
 	addCmd.Flags().StringVarP(&addWorkDir, "workdir", "w", "", "Working directory (optional)")
+	addCmd.Flags().StringVarP(&addProject, "project", "p", "", "Project group (optional)")
 	addCmd.Flags().BoolVar(&addDisabled, "disabled", false, "Create the job in disabled state")
 	addCmd.Flags().BoolVar(&addOnce, "once", false, "Run once at the specified datetime and then disable")
 
@@ -69,6 +71,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		Enabled:  !addDisabled,
 		Wrapped:  true,
 		OneShot:  addOnce,
+		Project:  addProject,
 	}
 
 	raw, err := cron.ReadCrontab()

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -36,8 +36,8 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(w, "STATUS\tNAME\tSCHEDULE\tCOMMAND")
-	fmt.Fprintln(w, "------\t----\t--------\t-------")
+	fmt.Fprintln(w, "STATUS\tNAME\tPROJECT\tSCHEDULE\tCOMMAND")
+	fmt.Fprintln(w, "------\t----\t-------\t--------\t-------")
 
 	for _, job := range jobs {
 		status := "enabled"
@@ -48,7 +48,11 @@ func runList(cmd *cobra.Command, args []string) error {
 		if len(cmdStr) > 60 {
 			cmdStr = cmdStr[:57] + "..."
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", status, job.Name, job.Schedule, cmdStr)
+		project := job.Project
+		if project == "" {
+			project = "-"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", status, job.Name, project, job.Schedule, cmdStr)
 	}
 
 	return w.Flush()

--- a/cron/parser.go
+++ b/cron/parser.go
@@ -17,6 +17,7 @@ type Job struct {
 	Tag      string // optional colored tag displayed after the name
 	TagColor string // hex color for the tag, e.g. "#f38ba8"
 	OneShot  bool   // true if this job should run once and then self-disable
+	Project  string // optional project group for organizing jobs
 }
 
 // recordBinPath returns the path to ~/.lazycron/bin/record.
@@ -99,6 +100,9 @@ func (j Job) CrontabLine() string {
 		}
 		nameComment += " [" + j.Tag + ":" + color + "]"
 	}
+	if j.Project != "" {
+		nameComment += " {" + j.Project + "}"
+	}
 	fmt.Fprintf(&b, "# %s\n", nameComment)
 
 	scriptCmd := "sh '" + ScriptPath(j.Name) + "'"
@@ -137,6 +141,8 @@ func Parse(output string) []Job {
 			name := strings.TrimSpace(strings.TrimPrefix(line, "#"))
 			var oneShot bool
 			name, oneShot = extractOnce(name)
+			project := ""
+			name, project = extractProject(name)
 			tag, tagColor := "", ""
 			name, tag, tagColor = extractTag(name)
 			i++
@@ -150,6 +156,7 @@ func Parse(output string) []Job {
 					job.Tag = tag
 					job.TagColor = tagColor
 					job.OneShot = oneShot
+					job.Project = project
 					jobs = append(jobs, job)
 					i++
 					continue
@@ -202,6 +209,21 @@ func extractTag(name string) (string, string, string) {
 	}
 	cleanName := strings.TrimSpace(name[:openIdx])
 	return cleanName, parts[0], parts[1]
+}
+
+// extractProject parses a project suffix from a name like "Job Name {my-project}".
+// Returns the clean name and project string.
+func extractProject(name string) (string, string) {
+	openIdx := strings.LastIndex(name, "{")
+	if openIdx == -1 || !strings.HasSuffix(name, "}") {
+		return name, ""
+	}
+	project := name[openIdx+1 : len(name)-1]
+	if project == "" {
+		return name, ""
+	}
+	cleanName := strings.TrimSpace(name[:openIdx])
+	return cleanName, project
 }
 
 func isNameComment(line string) bool {

--- a/cron/parser_test.go
+++ b/cron/parser_test.go
@@ -538,6 +538,126 @@ func TestFullRoundtrip_OneShot(t *testing.T) {
 	assertBool(t, "OneShot", got.OneShot, true)
 }
 
+// --- extractProject ---
+
+func TestExtractProject(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantName    string
+		wantProject string
+	}{
+		{"with project", "My Job {backend}", "My Job", "backend"},
+		{"no project", "My Job", "My Job", ""},
+		{"empty braces", "My Job {}", "My Job {}", ""},
+		{"project with tag", "My Job [TAG:#f38ba8] {backend}", "My Job [TAG:#f38ba8]", "backend"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotProject := extractProject(tt.input)
+			if gotName != tt.wantName {
+				t.Errorf("extractProject(%q) name = %q, want %q", tt.input, gotName, tt.wantName)
+			}
+			if gotProject != tt.wantProject {
+				t.Errorf("extractProject(%q) project = %q, want %q", tt.input, gotProject, tt.wantProject)
+			}
+		})
+	}
+}
+
+// --- Parse with project ---
+
+func TestParse_WithProject(t *testing.T) {
+	input := "# my-job [PROD:#f38ba8] {backend}\n* * * * * " + wrapCmd("echo hello", "my-job")
+	jobs := Parse(input)
+
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	j := jobs[0]
+	assertEqual(t, "Name", j.Name, "my-job")
+	assertEqual(t, "Tag", j.Tag, "PROD")
+	assertEqual(t, "TagColor", j.TagColor, "#f38ba8")
+	assertEqual(t, "Project", j.Project, "backend")
+}
+
+func TestParse_ProjectOnly(t *testing.T) {
+	input := "# my-job {infra}\n* * * * * " + wrapCmd("echo hello", "my-job")
+	jobs := Parse(input)
+
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	j := jobs[0]
+	assertEqual(t, "Name", j.Name, "my-job")
+	assertEqual(t, "Tag", j.Tag, "")
+	assertEqual(t, "Project", j.Project, "infra")
+}
+
+func TestParse_OneShotWithProject(t *testing.T) {
+	input := "# deploy @once [PROD:#f38ba8] {releases}\n30 14 22 3 * " + wrapCmd("echo deploy", "deploy")
+	jobs := Parse(input)
+
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	j := jobs[0]
+	assertEqual(t, "Name", j.Name, "deploy")
+	assertBool(t, "OneShot", j.OneShot, true)
+	assertEqual(t, "Tag", j.Tag, "PROD")
+	assertEqual(t, "Project", j.Project, "releases")
+}
+
+func TestCrontabLine_WithProject(t *testing.T) {
+	withFakeScriptsDir(t)
+	j := Job{Name: "my-job", Schedule: "0 9 * * *", Command: "echo hi", Enabled: true, Wrapped: true, Project: "backend"}
+	line := j.CrontabLine()
+
+	if !strings.HasPrefix(line, "# my-job {backend}\n") {
+		t.Errorf("expected project in name comment: %q", line)
+	}
+}
+
+func TestCrontabLine_TagAndProject(t *testing.T) {
+	withFakeScriptsDir(t)
+	j := Job{Name: "my-job", Schedule: "0 9 * * *", Command: "echo hi", Enabled: true, Wrapped: true, Tag: "PROD", TagColor: "#f38ba8", Project: "backend"}
+	line := j.CrontabLine()
+
+	if !strings.Contains(line, "# my-job [PROD:#f38ba8] {backend}\n") {
+		t.Errorf("expected tag before project in name comment: %q", line)
+	}
+}
+
+func TestFullRoundtrip_WithProject(t *testing.T) {
+	withFakeScriptsDir(t)
+	original := Job{
+		Name:     "project-test",
+		Schedule: "30 14 * * 1-5",
+		Command:  "echo hello",
+		Enabled:  true,
+		Wrapped:  true,
+		Tag:      "BP",
+		TagColor: "#a6e3a1",
+		Project:  "backend",
+	}
+
+	if err := WriteScript(original.Name, original.Command); err != nil {
+		t.Fatalf("WriteScript: %v", err)
+	}
+
+	line := original.CrontabLine()
+	jobs := Parse(line)
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job after roundtrip, got %d", len(jobs))
+	}
+
+	got := jobs[0]
+	assertEqual(t, "Name", got.Name, original.Name)
+	assertEqual(t, "Tag", got.Tag, original.Tag)
+	assertEqual(t, "TagColor", got.TagColor, original.TagColor)
+	assertEqual(t, "Project", got.Project, original.Project)
+}
+
 // --- helpers ---
 
 func assertEqual(t *testing.T, field, got, want string) {

--- a/ui/bars.go
+++ b/ui/bars.go
@@ -140,6 +140,7 @@ func renderHelpScreen() string {
 		{"space", "Toggle enable/disable"},
 		{"r", "Run job now"},
 		{"U", "Update job to latest format"},
+		{"p", "Set/change project group"},
 		{"", "── General ──"},
 		{"1/2/3/4/tab", "Switch panel"},
 		{"R", "Refresh from crontab"},

--- a/ui/detail.go
+++ b/ui/detail.go
@@ -50,6 +50,12 @@ func renderDetail(job *cron.Job, width int) string {
 	b.WriteString(renderDetailRow("Name", nameDisplay))
 	b.WriteString("\n")
 
+	// Project
+	if job.Project != "" {
+		b.WriteString(renderDetailRow("Project", detailValueStyle.Render(job.Project)))
+		b.WriteString("\n")
+	}
+
 	// Schedule
 	b.WriteString(renderDetailRow("Schedule", detailValueStyle.Render(cron.CronToHuman(job.Schedule))))
 	b.WriteString("\n")

--- a/ui/form.go
+++ b/ui/form.go
@@ -15,7 +15,8 @@ const (
 	fieldCommand  = 1
 	fieldSchedule = 2
 	fieldWorkDir  = 3
-	fieldCount    = 4
+	fieldProject  = 4
+	fieldCount    = 5
 )
 
 var fieldLabels = [fieldCount]string{
@@ -23,6 +24,7 @@ var fieldLabels = [fieldCount]string{
 	"Command",
 	"Schedule",
 	"Work Dir",
+	"Project",
 }
 
 var fieldHints = [fieldCount]string{
@@ -30,6 +32,7 @@ var fieldHints = [fieldCount]string{
 	"Shell command to execute",
 	"Cron expression or 'every day at 9am'",
 	"Optional: working directory",
+	"Optional: group name for organizing jobs",
 }
 
 type formModel struct {
@@ -88,6 +91,7 @@ func newFormForEdit(job cron.Job, index int) formModel {
 	f.inputs[fieldCommand].SetValue(cmd)
 	f.inputs[fieldSchedule].SetValue(job.Schedule)
 	f.inputs[fieldWorkDir].SetValue(workDir)
+	f.inputs[fieldProject].SetValue(job.Project)
 	f.tag = job.Tag
 	f.tagColor = job.TagColor
 	f.oneShot = job.OneShot
@@ -206,6 +210,7 @@ func (f *formModel) buildJob() (cron.Job, error) {
 		Tag:      f.tag,
 		TagColor: f.tagColor,
 		OneShot:  f.oneShot,
+		Project:  strings.TrimSpace(f.inputs[fieldProject].Value()),
 	}, nil
 }
 

--- a/ui/joblist.go
+++ b/ui/joblist.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -9,7 +10,80 @@ import (
 	"github.com/swalha1999/lazycron/cron"
 )
 
-func renderJobList(jobs []cron.Job, selected int, width, height int) string {
+// rowKind distinguishes between project header rows and job rows in the list.
+type rowKind int
+
+const (
+	rowJob    rowKind = iota
+	rowHeader         // collapsible project header
+)
+
+// listRow represents a single visual row in the grouped job list.
+type listRow struct {
+	kind    rowKind
+	jobIdx  int    // index into []cron.Job (only valid when kind == rowJob)
+	project string // project name (for headers and jobs; "" means ungrouped)
+}
+
+// projectGroup holds the group name and the original indices of its jobs.
+type projectGroup struct {
+	name    string
+	jobIdxs []int
+}
+
+// buildRows constructs the visual row list from jobs grouped by project.
+// Projects are sorted alphabetically, with the "Ungrouped" section at the bottom.
+func buildRows(jobs []cron.Job, collapsed map[string]bool) []listRow {
+	groups := groupByProject(jobs)
+	var rows []listRow
+	for _, g := range groups {
+		rows = append(rows, listRow{kind: rowHeader, project: g.name})
+		if !collapsed[g.name] {
+			for _, idx := range g.jobIdxs {
+				rows = append(rows, listRow{kind: rowJob, jobIdx: idx, project: g.name})
+			}
+		}
+	}
+	return rows
+}
+
+// groupByProject groups jobs by their Project field.
+// Named projects are sorted alphabetically; ungrouped jobs appear last.
+func groupByProject(jobs []cron.Job) []projectGroup {
+	groupMap := make(map[string][]int)
+	for i, j := range jobs {
+		groupMap[j.Project] = append(groupMap[j.Project], i)
+	}
+
+	var named []string
+	for name := range groupMap {
+		if name != "" {
+			named = append(named, name)
+		}
+	}
+	sort.Strings(named)
+
+	var groups []projectGroup
+	for _, name := range named {
+		groups = append(groups, projectGroup{name: name, jobIdxs: groupMap[name]})
+	}
+	if idxs, ok := groupMap[""]; ok {
+		groups = append(groups, projectGroup{name: "", jobIdxs: idxs})
+	}
+	return groups
+}
+
+// rowForJobIdx finds the visual row index for a given job index, or 0 if not found.
+func rowForJobIdx(rows []listRow, jobIdx int) int {
+	for i, r := range rows {
+		if r.kind == rowJob && r.jobIdx == jobIdx {
+			return i
+		}
+	}
+	return 0
+}
+
+func renderJobList(jobs []cron.Job, selRow int, rows []listRow, width, height int, collapsed map[string]bool) string {
 	if len(jobs) == 0 {
 		empty := mutedItemStyle.Render("No cron jobs found")
 		hint := mutedItemStyle.Render("Press 'n' to create one")
@@ -37,74 +111,110 @@ func renderJobList(jobs []cron.Job, selected int, width, height int) string {
 	}
 
 	startIdx := 0
-	if selected >= listHeight {
-		startIdx = selected - listHeight + 1
+	if selRow >= listHeight {
+		startIdx = selRow - listHeight + 1
 	}
 	endIdx := startIdx + listHeight
-	if endIdx > len(jobs) {
-		endIdx = len(jobs)
+	if endIdx > len(rows) {
+		endIdx = len(rows)
 	}
 
 	for i := startIdx; i < endIdx; i++ {
-		job := jobs[i]
+		row := rows[i]
 
-		// Status dot
-		dot := enabledDotStyle.Render("●")
-		if !job.Enabled {
-			dot = disabledDotStyle.Render("○")
-		}
-
-		// Name (truncated) with inline tag and badge
-		name := job.Name
-		if len(name) > maxNameWidth {
-			name = name[:maxNameWidth-1] + "…"
-		}
-
-		// Build inline badges right after the name
-		nameWithBadges := name
-		if job.Tag != "" {
-			tagColor := job.TagColor
-			if tagColor == "" {
-				tagColor = string(colorRed)
+		if row.kind == rowHeader {
+			line := renderGroupHeader(row.project, jobs, collapsed)
+			if i == selRow {
+				line = selectedStyle.Render("▶ " + line)
+			} else {
+				line = normalStyle.Render("  " + line)
 			}
-			nameWithBadges += " " + lipgloss.NewStyle().
-				Foreground(lipgloss.Color(tagColor)).
-				Bold(true).
-				Render(job.Tag)
-		}
-		if job.OneShot {
-			nameWithBadges += " " + lipgloss.NewStyle().Foreground(colorYellow).Bold(true).Render("ONCE")
-		}
-		if !job.Wrapped {
-			nameWithBadges += " " + warnStyle.Render("⚠")
-		}
-
-		// Schedule (human readable)
-		schedule := cron.CronToHuman(job.Schedule)
-		if len(schedule) > 24 {
-			schedule = schedule[:23] + "…"
-		}
-
-		line := fmt.Sprintf(" %s %s  %s", dot, nameWithBadges, mutedItemStyle.Render(schedule))
-
-		if i == selected {
-			line = selectedStyle.Render("▶ " + line)
+			b.WriteString(line)
 		} else {
-			line = normalStyle.Render("  " + line)
+			job := jobs[row.jobIdx]
+			line := renderJobRow(job, maxNameWidth)
+			if i == selRow {
+				line = selectedStyle.Render("▶ " + line)
+			} else {
+				line = normalStyle.Render("  " + line)
+			}
+			b.WriteString(line)
 		}
 
-		b.WriteString(line)
 		if i < endIdx-1 {
 			b.WriteString("\n")
 		}
 	}
 
 	// Scroll indicator
-	if len(jobs) > listHeight {
-		scrollInfo := fmt.Sprintf(" %d/%d", selected+1, len(jobs))
+	if len(rows) > listHeight {
+		scrollInfo := fmt.Sprintf(" %d/%d", selRow+1, len(rows))
 		b.WriteString("\n")
 		b.WriteString(mutedItemStyle.Render(scrollInfo))
 	}
 
 	return b.String()
+}
+
+func renderGroupHeader(project string, jobs []cron.Job, collapsed map[string]bool) string {
+	displayName := project
+	if project == "" {
+		displayName = "Ungrouped"
+	}
+
+	count := 0
+	for _, j := range jobs {
+		if j.Project == project {
+			count++
+		}
+	}
+
+	arrow := "▼"
+	if collapsed[project] {
+		arrow = "▶"
+	}
+
+	header := fmt.Sprintf("%s %s (%d)", arrow, displayName, count)
+	return lipgloss.NewStyle().Foreground(colorMauve).Bold(true).Render(header)
+}
+
+func renderJobRow(job cron.Job, maxNameWidth int) string {
+	// Status dot
+	dot := enabledDotStyle.Render("●")
+	if !job.Enabled {
+		dot = disabledDotStyle.Render("○")
+	}
+
+	// Name (truncated) with inline tag and badge
+	name := job.Name
+	if len(name) > maxNameWidth {
+		name = name[:maxNameWidth-1] + "…"
+	}
+
+	// Build inline badges right after the name
+	nameWithBadges := name
+	if job.Tag != "" {
+		tagColor := job.TagColor
+		if tagColor == "" {
+			tagColor = string(colorRed)
+		}
+		nameWithBadges += " " + lipgloss.NewStyle().
+			Foreground(lipgloss.Color(tagColor)).
+			Bold(true).
+			Render(job.Tag)
+	}
+	if job.OneShot {
+		nameWithBadges += " " + lipgloss.NewStyle().Foreground(colorYellow).Bold(true).Render("ONCE")
+	}
+	if !job.Wrapped {
+		nameWithBadges += " " + warnStyle.Render("⚠")
+	}
+
+	// Schedule (human readable)
+	schedule := cron.CronToHuman(job.Schedule)
+	if len(schedule) > 24 {
+		schedule = schedule[:23] + "…"
+	}
+
+	return fmt.Sprintf("   %s %s  %s", dot, nameWithBadges, mutedItemStyle.Render(schedule))
 }

--- a/ui/model.go
+++ b/ui/model.go
@@ -22,6 +22,7 @@ const (
 	modeNewJobChoice
 	modeTemplatePicker
 	modeConfirmDeleteHistory
+	modeProjectPrompt
 )
 
 type statusType int
@@ -79,6 +80,12 @@ type Model struct {
 	// Template picker state
 	templatePicker templatePickerModel
 
+	// Project grouping state
+	collapsedProjects map[string]bool
+	jobListRows       []listRow       // cached visual rows for grouped job list
+	selectedRow       int             // visual row index in grouped job list
+	projectInput      textinput.Model // for quick-assign project prompt
+
 	// App version (for self-update)
 	version string
 }
@@ -96,12 +103,24 @@ func newPasswordInput() textinput.Model {
 	return ti
 }
 
+func newProjectInput() textinput.Model {
+	ti := textinput.New()
+	ti.Prompt = ""
+	ti.Placeholder = "Project name (empty to clear)"
+	ti.CharLimit = 64
+	ti.PlaceholderStyle = lipgloss.NewStyle().Foreground(colorMuted)
+	ti.TextStyle = lipgloss.NewStyle().Foreground(colorFg)
+	ti.Cursor.Style = lipgloss.NewStyle().Foreground(colorHighlight)
+	return ti
+}
+
 func NewModel(mgr *backend.Manager, version string) Model {
 	return Model{
-		manager:    mgr,
-		selected:   0,
-		mode:       modeNormal,
-		focusPanel: panelServers,
-		version:    version,
+		manager:           mgr,
+		selected:          0,
+		mode:              modeNormal,
+		focusPanel:        panelServers,
+		collapsedProjects: make(map[string]bool),
+		version:           version,
 	}
 }

--- a/ui/update.go
+++ b/ui/update.go
@@ -155,6 +155,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.jobs = msg.jobs
 			m.history = msg.history
 			m.selected = 0
+			m.selectedRow = 0
 			m.historySelected = 0
 			serverName := m.manager.ServerAt(msg.index).Name
 			m.statusMsg = fmt.Sprintf("Switched to %s", serverName)
@@ -219,6 +220,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var cmd tea.Cmd
 		m.passwordInput, cmd = m.passwordInput.Update(msg)
 		return m, cmd
+	case modeProjectPrompt:
+		var cmd tea.Cmd
+		m.projectInput, cmd = m.projectInput.Update(msg)
+		return m, cmd
 	case modeTemplatePicker:
 		if m.templatePicker.phase == phaseVariables && len(m.templatePicker.variableInputs) > 0 {
 			idx := m.templatePicker.activeVariable
@@ -256,6 +261,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleNewJobChoiceKey(msg)
 	case modeTemplatePicker:
 		return m.handleTemplatePickerKey(msg)
+	case modeProjectPrompt:
+		return m.handleProjectPromptKey(msg)
 	default:
 		return m.handleNormalKey(msg)
 	}

--- a/ui/update_dialogs.go
+++ b/ui/update_dialogs.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -11,12 +12,11 @@ import (
 func (m Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "y", "Y":
-		if len(m.jobs) > 0 {
-			name := m.jobs[m.selected].Name
-			m.jobs = append(m.jobs[:m.selected], m.jobs[m.selected+1:]...)
-			if m.selected >= len(m.jobs) && m.selected > 0 {
-				m.selected--
-			}
+		jobIdx := m.currentJobIndex()
+		if jobIdx >= 0 && jobIdx < len(m.jobs) {
+			name := m.jobs[jobIdx].Name
+			m.jobs = append(m.jobs[:jobIdx], m.jobs[jobIdx+1:]...)
+			m.clampSelectedRow()
 			m.statusMsg = fmt.Sprintf("Deleted job '%s'", name)
 			m.statusKind = statusSuccess
 			m.mode = modeNormal
@@ -66,6 +66,42 @@ func (m Model) handleConfirmDeleteHistoryKey(msg tea.KeyMsg) (tea.Model, tea.Cmd
 		m.statusKind = statusInfo
 		m.statusID++
 		return m, clearStatusAfter(m.statusID, 3*time.Second)
+	}
+	return m, nil
+}
+
+func (m Model) handleProjectPromptKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "enter":
+		jobIdx := m.currentJobIndex()
+		if jobIdx >= 0 {
+			newProject := strings.TrimSpace(m.projectInput.Value())
+			m.jobs[jobIdx].Project = newProject
+			m.mode = modeNormal
+			if newProject != "" {
+				m.statusMsg = fmt.Sprintf("Set project '%s' on '%s'", newProject, m.jobs[jobIdx].Name)
+			} else {
+				m.statusMsg = fmt.Sprintf("Cleared project on '%s'", m.jobs[jobIdx].Name)
+			}
+			m.statusKind = statusSuccess
+			m.statusID++
+			// Rebuild rows and move selection to follow the job
+			rows := buildRows(m.jobs, m.collapsedProjects)
+			m.selectedRow = rowForJobIdx(rows, jobIdx)
+			b := m.manager.ActiveBackend()
+			return m, tea.Batch(saveJobs(b, m.jobs), clearStatusAfter(m.statusID, 4*time.Second))
+		}
+		m.mode = modeNormal
+	case "esc":
+		m.mode = modeNormal
+		m.statusMsg = "Cancelled"
+		m.statusKind = statusInfo
+		m.statusID++
+		return m, clearStatusAfter(m.statusID, 3*time.Second)
+	default:
+		var cmd tea.Cmd
+		m.projectInput, cmd = m.projectInput.Update(msg)
+		return m, cmd
 	}
 	return m, nil
 }

--- a/ui/update_form.go
+++ b/ui/update_form.go
@@ -117,10 +117,15 @@ func (m Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.form.editing {
 			job.Enabled = m.jobs[m.form.editIndex].Enabled
 			m.jobs[m.form.editIndex] = job
+			// Re-position selection to follow the job (project may have changed)
+			rows := buildRows(m.jobs, m.collapsedProjects)
+			m.selectedRow = rowForJobIdx(rows, m.form.editIndex)
 			m.statusMsg = fmt.Sprintf("Updated job '%s'", job.Name)
 		} else {
 			m.jobs = append(m.jobs, job)
-			m.selected = len(m.jobs) - 1
+			// Point selectedRow to the new job's visual row
+			rows := buildRows(m.jobs, m.collapsedProjects)
+			m.selectedRow = rowForJobIdx(rows, len(m.jobs)-1)
 			m.statusMsg = fmt.Sprintf("Created job '%s'", job.Name)
 		}
 		m.statusKind = statusSuccess

--- a/ui/update_normal.go
+++ b/ui/update_normal.go
@@ -8,6 +8,54 @@ import (
 	"github.com/swalha1999/lazycron/backend"
 )
 
+// currentJobIndex returns the job index for the current selectedRow, or -1 if on a header.
+func (m *Model) currentJobIndex() int {
+	rows := buildRows(m.jobs, m.collapsedProjects)
+	if m.selectedRow < 0 || m.selectedRow >= len(rows) {
+		return -1
+	}
+	if rows[m.selectedRow].kind == rowJob {
+		return rows[m.selectedRow].jobIdx
+	}
+	return -1
+}
+
+// isOnHeader returns true if the current selectedRow is a group header.
+func (m *Model) isOnHeader() bool {
+	rows := buildRows(m.jobs, m.collapsedProjects)
+	if m.selectedRow < 0 || m.selectedRow >= len(rows) {
+		return false
+	}
+	return rows[m.selectedRow].kind == rowHeader
+}
+
+// toggleCurrentHeader toggles the collapse state of the header at selectedRow.
+func (m *Model) toggleCurrentHeader() {
+	rows := buildRows(m.jobs, m.collapsedProjects)
+	if m.selectedRow < 0 || m.selectedRow >= len(rows) {
+		return
+	}
+	if rows[m.selectedRow].kind == rowHeader {
+		project := rows[m.selectedRow].project
+		m.collapsedProjects[project] = !m.collapsedProjects[project]
+	}
+}
+
+// clampSelectedRow ensures selectedRow is within bounds of current rows.
+func (m *Model) clampSelectedRow() {
+	rows := buildRows(m.jobs, m.collapsedProjects)
+	if len(rows) == 0 {
+		m.selectedRow = 0
+		return
+	}
+	if m.selectedRow >= len(rows) {
+		m.selectedRow = len(rows) - 1
+	}
+	if m.selectedRow < 0 {
+		m.selectedRow = 0
+	}
+}
+
 func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "q":
@@ -47,10 +95,12 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.serverSelected--
 			}
 		case panelJobs:
-			if m.selected > 0 {
-				m.selected--
+			rows := buildRows(m.jobs, m.collapsedProjects)
+			if m.selectedRow > 0 {
+				m.selectedRow--
 				m.detailScroll = 0
 			}
+			_ = rows
 		case panelHistory:
 			if m.historySelected > 0 {
 				m.historySelected--
@@ -69,8 +119,9 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.serverSelected++
 			}
 		case panelJobs:
-			if m.selected < len(m.jobs)-1 {
-				m.selected++
+			rows := buildRows(m.jobs, m.collapsedProjects)
+			if m.selectedRow < len(rows)-1 {
+				m.selectedRow++
 				m.detailScroll = 0
 			}
 		case panelHistory:
@@ -87,18 +138,29 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m.switchToServer(m.serverSelected)
 		}
 		if m.focusPanel == panelJobs && len(m.jobs) > 0 {
-			m.mode = modeForm
-			m.form = newFormForEdit(m.jobs[m.selected], m.selected)
-			m.statusMsg = ""
-			return m, m.form.focusActive()
+			if m.isOnHeader() {
+				m.toggleCurrentHeader()
+				m.clampSelectedRow()
+				return m, nil
+			}
+			jobIdx := m.currentJobIndex()
+			if jobIdx >= 0 {
+				m.mode = modeForm
+				m.form = newFormForEdit(m.jobs[jobIdx], jobIdx)
+				m.statusMsg = ""
+				return m, m.form.focusActive()
+			}
 		}
 
 	case "e":
-		if m.focusPanel == panelJobs && len(m.jobs) > 0 {
-			m.mode = modeForm
-			m.form = newFormForEdit(m.jobs[m.selected], m.selected)
-			m.statusMsg = ""
-			return m, m.form.focusActive()
+		if m.focusPanel == panelJobs && len(m.jobs) > 0 && !m.isOnHeader() {
+			jobIdx := m.currentJobIndex()
+			if jobIdx >= 0 {
+				m.mode = modeForm
+				m.form = newFormForEdit(m.jobs[jobIdx], jobIdx)
+				m.statusMsg = ""
+				return m, m.form.focusActive()
+			}
 		}
 
 	case "a":
@@ -164,7 +226,7 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			m.mode = modeConfirmDeleteServer
 			m.statusMsg = ""
-		} else if m.focusPanel == panelJobs && len(m.jobs) > 0 {
+		} else if m.focusPanel == panelJobs && len(m.jobs) > 0 && !m.isOnHeader() {
 			m.mode = modeConfirmDelete
 			m.statusMsg = ""
 		} else if m.focusPanel == panelHistory && len(m.history) > 0 {
@@ -177,42 +239,68 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m.switchToServer(m.serverSelected)
 		}
 		if m.focusPanel == panelJobs && len(m.jobs) > 0 {
-			m.jobs[m.selected].Enabled = !m.jobs[m.selected].Enabled
-			status := "enabled"
-			if !m.jobs[m.selected].Enabled {
-				status = "disabled"
+			if m.isOnHeader() {
+				m.toggleCurrentHeader()
+				m.clampSelectedRow()
+				return m, nil
 			}
-			m.statusMsg = fmt.Sprintf("Job '%s' %s", m.jobs[m.selected].Name, status)
-			m.statusKind = statusSuccess
-			m.statusID++
-			b := m.manager.ActiveBackend()
-			return m, tea.Batch(saveJobs(b, m.jobs), clearStatusAfter(m.statusID, 4*time.Second))
+			jobIdx := m.currentJobIndex()
+			if jobIdx >= 0 {
+				m.jobs[jobIdx].Enabled = !m.jobs[jobIdx].Enabled
+				status := "enabled"
+				if !m.jobs[jobIdx].Enabled {
+					status = "disabled"
+				}
+				m.statusMsg = fmt.Sprintf("Job '%s' %s", m.jobs[jobIdx].Name, status)
+				m.statusKind = statusSuccess
+				m.statusID++
+				b := m.manager.ActiveBackend()
+				return m, tea.Batch(saveJobs(b, m.jobs), clearStatusAfter(m.statusID, 4*time.Second))
+			}
+		}
+
+	case "p":
+		if m.focusPanel == panelJobs && len(m.jobs) > 0 && !m.isOnHeader() {
+			jobIdx := m.currentJobIndex()
+			if jobIdx >= 0 {
+				m.projectInput = newProjectInput()
+				m.projectInput.SetValue(m.jobs[jobIdx].Project)
+				m.mode = modeProjectPrompt
+				m.statusMsg = ""
+				return m, m.projectInput.Focus()
+			}
 		}
 
 	case "r":
-		if m.focusPanel == panelJobs && len(m.jobs) > 0 {
-			job := m.jobs[m.selected]
-			m.statusMsg = fmt.Sprintf("Running '%s'...", job.Name)
-			m.statusKind = statusInfo
-			b := m.manager.ActiveBackend()
-			return m, runJob(b, job.Name, job.Command)
+		if m.focusPanel == panelJobs && len(m.jobs) > 0 && !m.isOnHeader() {
+			jobIdx := m.currentJobIndex()
+			if jobIdx >= 0 {
+				job := m.jobs[jobIdx]
+				m.statusMsg = fmt.Sprintf("Running '%s'...", job.Name)
+				m.statusKind = statusInfo
+				b := m.manager.ActiveBackend()
+				return m, runJob(b, job.Name, job.Command)
+			}
 		}
 
 	case "U":
-		if m.focusPanel == panelJobs && len(m.jobs) > 0 {
-			job := &m.jobs[m.selected]
-			if job.Wrapped {
-				m.statusMsg = fmt.Sprintf("Job '%s' is already up to date", job.Name)
-				m.statusKind = statusInfo
+		if m.focusPanel == panelJobs && len(m.jobs) > 0 && !m.isOnHeader() {
+			jobIdx := m.currentJobIndex()
+			if jobIdx >= 0 {
+				job := &m.jobs[jobIdx]
+				if job.Wrapped {
+					m.statusMsg = fmt.Sprintf("Job '%s' is already up to date", job.Name)
+					m.statusKind = statusInfo
+					m.statusID++
+					return m, clearStatusAfter(m.statusID, 3*time.Second)
+				}
+				job.Wrapped = true
+				m.statusMsg = fmt.Sprintf("Updated '%s' to latest format", job.Name)
+				m.statusKind = statusSuccess
 				m.statusID++
-				return m, clearStatusAfter(m.statusID, 3*time.Second)
+				b := m.manager.ActiveBackend()
+				return m, tea.Batch(saveJobs(b, m.jobs), clearStatusAfter(m.statusID, 4*time.Second))
 			}
-			job.Wrapped = true
-			m.statusMsg = fmt.Sprintf("Updated '%s' to latest format", job.Name)
-			m.statusKind = statusSuccess
-			m.statusID++
-			b := m.manager.ActiveBackend()
-			return m, tea.Batch(saveJobs(b, m.jobs), clearStatusAfter(m.statusID, 4*time.Second))
 		}
 
 	case "R":
@@ -255,6 +343,7 @@ func (m Model) switchToServer(index int) (tea.Model, tea.Cmd) {
 			m.jobs = cached.Jobs
 			m.history = cached.History
 			m.selected = 0
+			m.selectedRow = 0
 			m.historySelected = 0
 		}
 		return m, loadServerData(m.manager, index)

--- a/ui/view.go
+++ b/ui/view.go
@@ -33,8 +33,8 @@ func (m Model) View() string {
 
 	case modeConfirmDelete:
 		jobName := ""
-		if len(m.jobs) > 0 {
-			jobName = m.jobs[m.selected].Name
+		if jobIdx := m.selectedJobIndex(); jobIdx >= 0 {
+			jobName = m.jobs[jobIdx].Name
 		}
 		fg := renderConfirmDialog(fmt.Sprintf("Delete job '%s'?", jobName))
 		content = overlay(panels, fg, m.width, contentHeight)
@@ -78,6 +78,10 @@ func (m Model) View() string {
 
 	case modeTemplatePicker:
 		fg := renderTemplatePicker(&m.templatePicker, m.width)
+		content = overlay(panels, fg, m.width, contentHeight)
+
+	case modeProjectPrompt:
+		fg := renderProjectPrompt(&m.projectInput, m.jobs, m.selectedJobIndex(), m.width)
 		content = overlay(panels, fg, m.width, contentHeight)
 
 	default:
@@ -153,7 +157,8 @@ func (m Model) renderPanels(height int) string {
 	serversBox = injectBorderTitle(serversBox, "1", "Servers", serversActive)
 
 	// [2] Jobs panel
-	listContent := renderJobList(m.jobs, m.selected, listWidth-4, jobsHeight)
+	rows := buildRows(m.jobs, m.collapsedProjects)
+	listContent := renderJobList(m.jobs, m.selectedRow, rows, listWidth-4, jobsHeight, m.collapsedProjects)
 	jobsActive := m.focusPanel == panelJobs
 	jobsPanelStyle := panelStyle
 	if jobsActive {
@@ -207,11 +212,26 @@ func (m Model) buildDetailContent(width int) string {
 		}
 		return renderHistoryDetail(entry, width)
 	}
+	jobIdx := m.selectedJobIndex()
 	var selectedJob *cron.Job
-	if m.selected >= 0 && m.selected < len(m.jobs) {
-		selectedJob = &m.jobs[m.selected]
+	if jobIdx >= 0 && jobIdx < len(m.jobs) {
+		selectedJob = &m.jobs[jobIdx]
 	}
 	return renderDetail(selectedJob, width)
+}
+
+// selectedJobIndex returns the job index for the current visual row,
+// or -1 if on a header row or no jobs exist.
+func (m Model) selectedJobIndex() int {
+	rows := buildRows(m.jobs, m.collapsedProjects)
+	if m.selectedRow < 0 || m.selectedRow >= len(rows) {
+		return -1
+	}
+	row := rows[m.selectedRow]
+	if row.kind == rowJob {
+		return row.jobIdx
+	}
+	return -1
 }
 
 func (m Model) applyDetailScroll(detailContent string, innerHeight int) string {
@@ -352,6 +372,40 @@ func renderPasswordPrompt(input *textinput.Model, serverName, host, user string,
 	b.WriteString("\n\n")
 	b.WriteString("  " +
 		helpBinding("enter", "connect") + helpSep() +
+		helpBinding("esc", "cancel"))
+
+	return formStyle.Width(formWidth).Render(b.String())
+}
+
+func renderProjectPrompt(input *textinput.Model, jobs []cron.Job, selected, width int) string {
+	formWidth := width - 10
+	if formWidth > 50 {
+		formWidth = 50
+	}
+	if formWidth < 40 {
+		formWidth = 40
+	}
+
+	inputWidth := formWidth - 6
+
+	var b strings.Builder
+	b.WriteString(formTitleStyle.Render("  Set Project"))
+	b.WriteString("\n\n")
+	if selected >= 0 && selected < len(jobs) {
+		b.WriteString(mutedItemStyle.Render(fmt.Sprintf("  Job: %s", jobs[selected].Name)))
+		b.WriteString("\n\n")
+	}
+
+	label := formLabelStyle.Render("  Project:  ")
+	input.Width = inputWidth
+	rendered := lipgloss.NewStyle().
+		PaddingLeft(1).
+		PaddingRight(1).
+		Render(input.View())
+	b.WriteString(label + rendered)
+	b.WriteString("\n\n")
+	b.WriteString("  " +
+		helpBinding("enter", "save") + helpSep() +
 		helpBinding("esc", "cancel"))
 
 	return formStyle.Width(formWidth).Render(b.String())


### PR DESCRIPTION
## Summary
Closes #21

Adds a "Project" grouping concept so users can organize cron jobs into collapsible project sections in the job list panel.

- **Data model**: New `Project string` field on `Job` struct, stored in crontab comment as `{project-name}`
- **Parser**: Handles all combinations of tag/project/oneshot in comment lines with full roundtrip fidelity
- **Job form**: New "Project" text input field for setting project on create/edit
- **Job list**: Collapsible group headers (`▼ ProjectName (3)` / `▶ ProjectName (2)`) sorted alphabetically, ungrouped jobs at bottom
- **Navigation**: `j`/`k` moves through both headers and jobs; `enter`/`space` on headers toggles collapse
- **Quick-assign**: `p` keybinding opens a mini prompt to set/change project on the selected job
- **Detail panel**: Shows "Project: X" when a project is set
- **CLI**: `add --project` flag and `list` shows project column

## Test plan
- [x] All existing parser tests pass (backward compatible)
- [x] New parser tests cover: extractProject, parse with project, project-only, oneshot+tag+project, CrontabLine with project, full roundtrip with project
- [x] `go vet` clean
- [ ] Manual: create jobs with/without projects, verify grouping and collapse
- [ ] Manual: use `p` to quick-assign project, verify job moves to correct group
- [ ] Manual: edit job project in form, verify group changes
- [ ] Manual: verify `lazycron add --project X` works from CLI
- [ ] Manual: verify `lazycron list` shows project column