### PR TITLE
Fix #9: Restrict file permissions to owner-only access

### DIFF
--- a/cron/scripts.go
+++ b/cron/scripts.go
@@ -34,11 +34,11 @@ func sanitizeJobName(name string) string {
 // WriteScript writes a job's command to its script file.
 func WriteScript(jobName, command string) error {
 	dir := scriptsDir()
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
 	content := "#!/bin/sh\n" + ScriptPreamble + command + "\n"
-	return os.WriteFile(ScriptPath(jobName), []byte(content), 0755)
+	return os.WriteFile(ScriptPath(jobName), []byte(content), 0700)
 }
 
 // ScriptPreamble is the profile-sourcing block prepended to every script.
@@ -75,7 +75,7 @@ func DeleteScript(jobName string) error {
 // SyncScripts writes script files for all jobs and removes orphans.
 func SyncScripts(jobs []Job) error {
 	dir := scriptsDir()
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
 

--- a/cron/scripts_test.go
+++ b/cron/scripts_test.go
@@ -59,8 +59,8 @@ func TestWriteReadScript(t *testing.T) {
 
 	// Verify permissions
 	info, _ := os.Stat(path)
-	if info.Mode().Perm() != 0755 {
-		t.Errorf("permissions = %o, want 0755", info.Mode().Perm())
+	if info.Mode().Perm() != 0700 {
+		t.Errorf("permissions = %o, want 0700", info.Mode().Perm())
 	}
 }
 

--- a/history/history.go
+++ b/history/history.go
@@ -84,5 +84,5 @@ func WriteEntry(jobName, output string, success bool) error {
 	filename := now.Format("2006-01-02T15-04-05") + "_" + safeName + ".json"
 	path := filepath.Join(record.HistoryDir(), filename)
 
-	return os.WriteFile(path, data, 0o644)
+	return os.WriteFile(path, data, 0o600)
 }

--- a/record/record.go
+++ b/record/record.go
@@ -36,10 +36,10 @@ func RecordPath() string {
 
 // EnsureDirs creates ~/.lazycron/bin/ and ~/.lazycron/history/.
 func EnsureDirs() error {
-	if err := os.MkdirAll(BinDir(), 0o755); err != nil {
+	if err := os.MkdirAll(BinDir(), 0o700); err != nil {
 		return err
 	}
-	return os.MkdirAll(HistoryDir(), 0o755)
+	return os.MkdirAll(HistoryDir(), 0o700)
 }
 
 // InstallRecord writes the embedded POSIX shell script to ~/.lazycron/bin/record.

--- a/record/record.sh
+++ b/record/record.sh
@@ -13,7 +13,8 @@ EXIT="${2:-0}"
 OUTPUT="$(cat)"
 
 DIR="$HOME/.lazycron/history"
-mkdir -p "$DIR"
+mkdir -p -m 0700 "$DIR"
+umask 077
 
 STAMP="$(date +%Y-%m-%dT%H-%M-%S)"
 SAFE="$(printf '%s' "$JOB" | tr '/ ' '__')"


### PR DESCRIPTION
Closes #9

## Summary
Script files, history files, and their directories were created with world-readable permissions (`0755`/`0644`), allowing any local user to read cron job commands containing secrets and job output containing sensitive data.

## Changes
- **Script files**: `0755` → `0700` (owner-only rwx)
- **Script directories**: `0755` → `0700`
- **History files**: `0644` → `0600` (owner-only rw)
- **History/bin directories**: `0755` → `0700`
- **record.sh**: Added `umask 077` and `mkdir -m 0700` so shell-created history files also get restricted permissions
- Updated test expectations to match new permissions