### PR TITLE
Feat #7: Add E2E tests for TUI using file-based crontab backend

### DIFF
--- a/backend/file_backend.go
+++ b/backend/file_backend.go
@@ -1,0 +1,76 @@
+package backend
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/swalha1999/lazycron/cron"
+	"github.com/swalha1999/lazycron/history"
+)
+
+// FileBackend reads/writes a plain crontab file and uses a temp history
+// directory instead of the system crontab. Useful for testing and dry-run.
+type FileBackend struct {
+	cronFile   string
+	historyDir string
+}
+
+// NewFileBackend creates a backend backed by a crontab file and history directory.
+func NewFileBackend(cronFile, historyDir string) *FileBackend {
+	return &FileBackend{
+		cronFile:   cronFile,
+		historyDir: historyDir,
+	}
+}
+
+func (b *FileBackend) Name() string { return "file:" + b.cronFile }
+
+func (b *FileBackend) ReadJobs() ([]cron.Job, error) {
+	data, err := os.ReadFile(b.cronFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return cron.Parse(string(data)), nil
+}
+
+func (b *FileBackend) WriteJobs(jobs []cron.Job) error {
+	content := cron.FormatCrontab(jobs)
+	return os.WriteFile(b.cronFile, []byte(content), 0o644)
+}
+
+func (b *FileBackend) RunJob(name, command string) (string, error) {
+	cmd := exec.Command("sh", "-c", command)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func (b *FileBackend) LoadHistory() ([]history.Entry, error) {
+	if err := os.MkdirAll(b.historyDir, 0o755); err != nil {
+		return nil, err
+	}
+	return history.LoadAllFrom(b.historyDir)
+}
+
+func (b *FileBackend) WriteHistory(jobName, output string, success bool) error {
+	if err := os.MkdirAll(b.historyDir, 0o755); err != nil {
+		return err
+	}
+	return history.WriteEntryTo(b.historyDir, jobName, output, success)
+}
+
+func (b *FileBackend) DeleteHistory(filePath string) error {
+	// Safety: only delete files within our history directory.
+	if !strings.HasPrefix(filePath, b.historyDir) {
+		return fmt.Errorf("refusing to delete file outside history dir")
+	}
+	return os.Remove(filePath)
+}
+
+func (b *FileBackend) EnsureRecordScript() error { return nil }
+
+func (b *FileBackend) Close() error { return nil }

--- a/backend/file_backend_test.go
+++ b/backend/file_backend_test.go
@@ -1,0 +1,122 @@
+package backend
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/swalha1999/lazycron/cron"
+)
+
+func TestFileBackend_ReadWriteJobs(t *testing.T) {
+	dir := t.TempDir()
+	cronFile := filepath.Join(dir, "crontab")
+	histDir := filepath.Join(dir, "history")
+
+	fb := NewFileBackend(cronFile, histDir)
+
+	// Reading non-existent file returns empty.
+	jobs, err := fb.ReadJobs()
+	if err != nil {
+		t.Fatalf("ReadJobs on missing file: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("expected 0 jobs, got %d", len(jobs))
+	}
+
+	// Write jobs and read back.
+	want := []cron.Job{
+		{Name: "hello", Schedule: "* * * * *", Command: "echo hi", Enabled: true, Wrapped: true},
+	}
+	if err := fb.WriteJobs(want); err != nil {
+		t.Fatalf("WriteJobs: %v", err)
+	}
+
+	got, err := fb.ReadJobs()
+	if err != nil {
+		t.Fatalf("ReadJobs: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(got))
+	}
+	if got[0].Name != "hello" {
+		t.Errorf("name = %q, want %q", got[0].Name, "hello")
+	}
+}
+
+func TestFileBackend_History(t *testing.T) {
+	dir := t.TempDir()
+	cronFile := filepath.Join(dir, "crontab")
+	histDir := filepath.Join(dir, "history")
+
+	fb := NewFileBackend(cronFile, histDir)
+
+	// Write a history entry.
+	if err := fb.WriteHistory("test-job", "output", true); err != nil {
+		t.Fatalf("WriteHistory: %v", err)
+	}
+
+	entries, err := fb.LoadHistory()
+	if err != nil {
+		t.Fatalf("LoadHistory: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].JobName != "test-job" {
+		t.Errorf("JobName = %q, want %q", entries[0].JobName, "test-job")
+	}
+
+	// Delete the history entry.
+	if err := fb.DeleteHistory(entries[0].FilePath); err != nil {
+		t.Fatalf("DeleteHistory: %v", err)
+	}
+	entries, err = fb.LoadHistory()
+	if err != nil {
+		t.Fatalf("LoadHistory after delete: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected 0 entries after delete, got %d", len(entries))
+	}
+}
+
+func TestFileBackend_DeleteHistoryOutsideDir(t *testing.T) {
+	dir := t.TempDir()
+	cronFile := filepath.Join(dir, "crontab")
+	histDir := filepath.Join(dir, "history")
+
+	fb := NewFileBackend(cronFile, histDir)
+
+	// Attempting to delete a file outside the history dir should fail.
+	err := fb.DeleteHistory("/tmp/some-other-file")
+	if err == nil {
+		t.Fatal("expected error deleting file outside history dir")
+	}
+}
+
+func TestFileBackend_Name(t *testing.T) {
+	fb := NewFileBackend("/tmp/crontab", "/tmp/history")
+	if fb.Name() != "file:/tmp/crontab" {
+		t.Errorf("Name = %q", fb.Name())
+	}
+}
+
+func TestFileBackend_EmptyFileReturnsNoJobs(t *testing.T) {
+	dir := t.TempDir()
+	cronFile := filepath.Join(dir, "crontab")
+	histDir := filepath.Join(dir, "history")
+
+	// Create an empty file.
+	if err := os.WriteFile(cronFile, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fb := NewFileBackend(cronFile, histDir)
+	jobs, err := fb.ReadJobs()
+	if err != nil {
+		t.Fatalf("ReadJobs on empty file: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("expected 0 jobs, got %d", len(jobs))
+	}
+}

--- a/backend/manager.go
+++ b/backend/manager.go
@@ -61,6 +61,18 @@ func NewManager() *Manager {
 	}
 }
 
+// NewManagerWithBackend creates a manager with a custom backend at index 0.
+func NewManagerWithBackend(b Backend) *Manager {
+	return &Manager{
+		backends: []Backend{b},
+		servers: []ServerInfo{
+			{Name: b.Name(), Status: ConnLocal},
+		},
+		active: 0,
+		cache:  make(map[int]*CachedData),
+	}
+}
+
 // AddServer registers a remote server backend.
 func (m *Manager) AddServer(info ServerInfo, b Backend) {
 	m.mu.Lock()

--- a/backend/manager_test.go
+++ b/backend/manager_test.go
@@ -20,6 +20,7 @@ func (m *mockBackend) WriteJobs(jobs []cron.Job) error                     { ret
 func (m *mockBackend) RunJob(name, command string) (string, error)         { return "", nil }
 func (m *mockBackend) LoadHistory() ([]history.Entry, error)               { return nil, nil }
 func (m *mockBackend) WriteHistory(jobName, output string, ok bool) error  { return nil }
+func (m *mockBackend) DeleteHistory(filePath string) error                 { return nil }
 func (m *mockBackend) EnsureRecordScript() error                           { return nil }
 func (m *mockBackend) Close() error                                        { m.closed = true; return nil }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,8 +30,11 @@ func Execute() {
 	}
 }
 
+var cronFile string
+
 func init() {
 	rootCmd.Version = Version
+	rootCmd.Flags().StringVar(&cronFile, "cron-file", "", "use a plain crontab file instead of the system crontab (useful for testing/dry-run)")
 }
 
 // initBackendManager creates a backend.Manager with local + configured remote servers.
@@ -62,15 +65,26 @@ func initBackendManager() *backend.Manager {
 }
 
 func runTUI(cmd *cobra.Command, args []string) error {
-	if err := cron.CheckCrontabAvailable(); err != nil {
-		return err
-	}
+	var mgr *backend.Manager
 
-	if err := record.InstallRecord(); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not install record script: %v\n", err)
-	}
+	if cronFile != "" {
+		histDir := cronFile + ".history"
+		if err := os.MkdirAll(histDir, 0o755); err != nil {
+			return fmt.Errorf("create history dir: %w", err)
+		}
+		fb := backend.NewFileBackend(cronFile, histDir)
+		mgr = backend.NewManagerWithBackend(fb)
+	} else {
+		if err := cron.CheckCrontabAvailable(); err != nil {
+			return err
+		}
 
-	mgr := initBackendManager()
+		if err := record.InstallRecord(); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not install record script: %v\n", err)
+		}
+
+		mgr = initBackendManager()
+	}
 
 	p := tea.NewProgram(
 		ui.NewModel(mgr, Version),

--- a/e2e/tui_test.go
+++ b/e2e/tui_test.go
@@ -1,0 +1,370 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/swalha1999/lazycron/backend"
+	"github.com/swalha1999/lazycron/cron"
+	"github.com/swalha1999/lazycron/ui"
+)
+
+// testEnv sets up a temporary crontab file and history directory.
+type testEnv struct {
+	cronFile   string
+	historyDir string
+	fb         *backend.FileBackend
+	mgr        *backend.Manager
+}
+
+func newTestEnv(t *testing.T) *testEnv {
+	t.Helper()
+	dir := t.TempDir()
+	cronFile := filepath.Join(dir, "crontab")
+	histDir := filepath.Join(dir, "history")
+	if err := os.MkdirAll(histDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fb := backend.NewFileBackend(cronFile, histDir)
+	mgr := backend.NewManagerWithBackend(fb)
+	return &testEnv{
+		cronFile:   cronFile,
+		historyDir: histDir,
+		fb:         fb,
+		mgr:        mgr,
+	}
+}
+
+// prePopulate writes jobs to the crontab file.
+func (e *testEnv) prePopulate(t *testing.T, jobs []cron.Job) {
+	t.Helper()
+	if err := e.fb.WriteJobs(jobs); err != nil {
+		t.Fatalf("prePopulate: %v", err)
+	}
+}
+
+// readJobs reads jobs from the crontab file.
+func (e *testEnv) readJobs(t *testing.T) []cron.Job {
+	t.Helper()
+	jobs, err := e.fb.ReadJobs()
+	if err != nil {
+		t.Fatalf("readJobs: %v", err)
+	}
+	return jobs
+}
+
+// cronFileContents returns the raw crontab file contents.
+func (e *testEnv) cronFileContents(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(e.cronFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("reading cron file: %v", err)
+	}
+	return string(data)
+}
+
+// initModel creates a new TUI model and processes its Init command.
+func (e *testEnv) initModel(t *testing.T) tea.Model {
+	t.Helper()
+	m := ui.NewModel(e.mgr, "test")
+	cmd := m.Init()
+	return processCmd(m, cmd)
+}
+
+// execCmd runs a tea.Cmd with a short timeout. Returns the message or nil if
+// the command blocks (e.g. tick-based commands like blink or historyTick).
+func execCmd(cmd tea.Cmd) tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	ch := make(chan tea.Msg, 1)
+	go func() { ch <- cmd() }()
+	select {
+	case msg := <-ch:
+		return msg
+	case <-time.After(50 * time.Millisecond):
+		return nil // skip blocking commands (ticks, blinks)
+	}
+}
+
+// processCmd executes a tea.Cmd and feeds the resulting message back to the model.
+// It recursively processes batch commands. It skips tick-based commands
+// (blink, clearStatus, historyTick) that would block.
+func processCmd(m tea.Model, cmd tea.Cmd) tea.Model {
+	msg := execCmd(cmd)
+	if msg == nil {
+		return m
+	}
+
+	// Handle batch messages: tea.BatchMsg is []tea.Cmd in bubbletea v1.3.10
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			m = processCmd(m, c)
+		}
+		return m
+	}
+
+	var newCmd tea.Cmd
+	m, newCmd = m.Update(msg)
+	return processCmd(m, newCmd)
+}
+
+// sendKey sends a single-character key message to the model and processes the resulting command.
+func sendKey(m tea.Model, key string) tea.Model {
+	var cmd tea.Cmd
+	m, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)})
+	return processCmd(m, cmd)
+}
+
+// sendSpecialKey sends a special key (enter, tab, esc, space, etc.) to the model.
+func sendSpecialKey(m tea.Model, keyType tea.KeyType) tea.Model {
+	var cmd tea.Cmd
+	m, cmd = m.Update(tea.KeyMsg{Type: keyType})
+	return processCmd(m, cmd)
+}
+
+// sendString types a string character by character.
+func sendString(m tea.Model, s string) tea.Model {
+	for _, ch := range s {
+		var cmd tea.Cmd
+		m, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+		m = processCmd(m, cmd)
+	}
+	return m
+}
+
+// sampleJob creates a simple enabled job for pre-populating.
+func sampleJob(name, command, schedule string) cron.Job {
+	return cron.Job{
+		Name:     name,
+		Schedule: schedule,
+		Command:  command,
+		Enabled:  true,
+		Wrapped:  true,
+	}
+}
+
+// --- Test Cases ---
+
+func TestCreateBlankJob(t *testing.T) {
+	env := newTestEnv(t)
+	m := env.initModel(t)
+
+	// Focus on jobs panel: tab
+	m = sendSpecialKey(m, tea.KeyTab)
+
+	// Open new job menu: n
+	m = sendKey(m, "n")
+
+	// Choose blank form: b
+	m = sendKey(m, "b")
+
+	// Type name
+	m = sendString(m, "my-job")
+
+	// Tab to command field
+	m = sendSpecialKey(m, tea.KeyTab)
+
+	// Type command
+	m = sendString(m, "echo hello")
+
+	// Tab to schedule field (already has default "* * * * *" from picker)
+	m = sendSpecialKey(m, tea.KeyTab)
+
+	// Tab through the cron picker
+	m = sendSpecialKey(m, tea.KeyTab)
+
+	// Now on WorkDir — skip it. Submit with enter.
+	m = sendSpecialKey(m, tea.KeyEnter)
+
+	// Verify
+	jobs := env.readJobs(t)
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d\ncrontab contents:\n%s", len(jobs), env.cronFileContents(t))
+	}
+	if jobs[0].Name != "my-job" {
+		t.Errorf("job name = %q, want %q", jobs[0].Name, "my-job")
+	}
+}
+
+func TestDeleteJob(t *testing.T) {
+	env := newTestEnv(t)
+	env.prePopulate(t, []cron.Job{sampleJob("delete-me", "echo bye", "* * * * *")})
+	m := env.initModel(t)
+
+	// Focus jobs panel
+	m = sendSpecialKey(m, tea.KeyTab)
+
+	// Delete: D
+	m = sendKey(m, "D")
+
+	// Confirm: y
+	m = sendKey(m, "y")
+
+	// Verify
+	jobs := env.readJobs(t)
+	if len(jobs) != 0 {
+		t.Fatalf("expected 0 jobs after delete, got %d", len(jobs))
+	}
+}
+
+func TestToggleDisable(t *testing.T) {
+	env := newTestEnv(t)
+	env.prePopulate(t, []cron.Job{sampleJob("toggle-me", "echo hi", "* * * * *")})
+	m := env.initModel(t)
+
+	// Focus jobs panel
+	m = sendSpecialKey(m, tea.KeyTab)
+
+	// Toggle disable: space
+	m = sendSpecialKey(m, tea.KeySpace)
+
+	// Verify
+	content := env.cronFileContents(t)
+	if !strings.Contains(content, "#DISABLED") {
+		t.Fatalf("expected job to be disabled, crontab:\n%s", content)
+	}
+}
+
+func TestToggleReEnable(t *testing.T) {
+	env := newTestEnv(t)
+	disabledJob := sampleJob("toggle-me", "echo hi", "* * * * *")
+	disabledJob.Enabled = false
+	env.prePopulate(t, []cron.Job{disabledJob})
+	m := env.initModel(t)
+
+	// Focus jobs panel
+	m = sendSpecialKey(m, tea.KeyTab)
+
+	// Toggle enable: space
+	m = sendSpecialKey(m, tea.KeySpace)
+
+	// Verify
+	content := env.cronFileContents(t)
+	if strings.Contains(content, "#DISABLED") {
+		t.Fatalf("expected job to be enabled, crontab:\n%s", content)
+	}
+}
+
+func TestEditJob(t *testing.T) {
+	env := newTestEnv(t)
+	env.prePopulate(t, []cron.Job{sampleJob("old-name", "echo old", "* * * * *")})
+	m := env.initModel(t)
+
+	// Focus jobs panel
+	m = sendSpecialKey(m, tea.KeyTab)
+
+	// Edit: e
+	m = sendKey(m, "e")
+
+	// Clear the name field and type new name.
+	// The name field is focused. Select all and clear.
+	m = sendSpecialKey(m, tea.KeyCtrlA)
+	m = sendSpecialKey(m, tea.KeyCtrlK)
+	m = sendString(m, "new-name")
+
+	// Submit
+	m = sendSpecialKey(m, tea.KeyEnter)
+
+	// Verify
+	jobs := env.readJobs(t)
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	if jobs[0].Name != "new-name" {
+		t.Errorf("job name = %q, want %q", jobs[0].Name, "new-name")
+	}
+}
+
+func TestCancelForm(t *testing.T) {
+	env := newTestEnv(t)
+	m := env.initModel(t)
+
+	// Focus jobs panel, open new job menu, choose blank form
+	m = sendSpecialKey(m, tea.KeyTab)
+	m = sendKey(m, "n")
+	m = sendKey(m, "b")
+
+	// Type some data
+	m = sendString(m, "temp-job")
+
+	// Cancel with esc
+	m = sendSpecialKey(m, tea.KeyEscape)
+
+	// Verify: no file should exist or it should be empty
+	jobs := env.readJobs(t)
+	if len(jobs) != 0 {
+		t.Fatalf("expected 0 jobs after cancel, got %d", len(jobs))
+	}
+}
+
+func TestCreateMultipleJobs(t *testing.T) {
+	env := newTestEnv(t)
+	m := env.initModel(t)
+
+	// Create first job
+	m = sendSpecialKey(m, tea.KeyTab) // focus jobs panel
+	m = sendKey(m, "n")
+	m = sendKey(m, "b")
+	m = sendString(m, "job-one")
+	m = sendSpecialKey(m, tea.KeyTab) // → command
+	m = sendString(m, "echo one")
+	m = sendSpecialKey(m, tea.KeyTab) // → schedule (has default)
+	m = sendSpecialKey(m, tea.KeyTab) // → picker
+	m = sendSpecialKey(m, tea.KeyTab) // → workdir
+	m = sendSpecialKey(m, tea.KeyEnter)
+
+	// Create second job (we're back in normal mode on jobs panel)
+	m = sendKey(m, "n")
+	m = sendKey(m, "b")
+	m = sendString(m, "job-two")
+	m = sendSpecialKey(m, tea.KeyTab) // → command
+	m = sendString(m, "echo two")
+	m = sendSpecialKey(m, tea.KeyTab) // → schedule (has default)
+	m = sendSpecialKey(m, tea.KeyTab) // → picker
+	m = sendSpecialKey(m, tea.KeyTab) // → workdir
+	m = sendSpecialKey(m, tea.KeyEnter)
+
+	// Verify
+	jobs := env.readJobs(t)
+	if len(jobs) != 2 {
+		t.Fatalf("expected 2 jobs, got %d\ncrontab:\n%s", len(jobs), env.cronFileContents(t))
+	}
+}
+
+func TestDeleteSecondJob(t *testing.T) {
+	env := newTestEnv(t)
+	env.prePopulate(t, []cron.Job{
+		sampleJob("first", "echo 1", "* * * * *"),
+		sampleJob("second", "echo 2", "0 9 * * *"),
+	})
+	m := env.initModel(t)
+
+	// Focus jobs panel
+	m = sendSpecialKey(m, tea.KeyTab)
+
+	// Move down to second job: j
+	m = sendKey(m, "j")
+
+	// Delete: D
+	m = sendKey(m, "D")
+
+	// Confirm: y
+	m = sendKey(m, "y")
+
+	// Verify
+	jobs := env.readJobs(t)
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	if jobs[0].Name != "first" {
+		t.Errorf("remaining job = %q, want %q", jobs[0].Name, "first")
+	}
+}

--- a/history/history.go
+++ b/history/history.go
@@ -22,8 +22,11 @@ type Entry struct {
 
 // LoadAll reads all JSON files from ~/.lazycron/history/ sorted by timestamp desc.
 func LoadAll() ([]Entry, error) {
-	dir := record.HistoryDir()
+	return LoadAllFrom(record.HistoryDir())
+}
 
+// LoadAllFrom reads all JSON files from the given directory sorted by timestamp desc.
+func LoadAllFrom(dir string) ([]Entry, error) {
 	files, err := filepath.Glob(filepath.Join(dir, "*.json"))
 	if err != nil {
 		return nil, err
@@ -60,12 +63,16 @@ func LoadEntry(path string) (Entry, error) {
 	return e, nil
 }
 
-// WriteEntry writes a history entry to disk.
+// WriteEntry writes a history entry to the default history directory.
 func WriteEntry(jobName, output string, success bool) error {
 	if err := record.EnsureDirs(); err != nil {
 		return err
 	}
+	return WriteEntryTo(record.HistoryDir(), jobName, output, success)
+}
 
+// WriteEntryTo writes a history entry to the given directory.
+func WriteEntryTo(dir, jobName, output string, success bool) error {
 	now := time.Now()
 	e := record.Entry{
 		JobName:   jobName,
@@ -82,7 +89,7 @@ func WriteEntry(jobName, output string, success bool) error {
 	safeName := strings.ReplaceAll(jobName, "/", "_")
 	safeName = strings.ReplaceAll(safeName, " ", "_")
 	filename := now.Format("2006-01-02T15-04-05") + "_" + safeName + ".json"
-	path := filepath.Join(record.HistoryDir(), filename)
+	path := filepath.Join(dir, filename)
 
 	return os.WriteFile(path, data, 0o644)
 }


### PR DESCRIPTION
Closes #7

## Summary
- **Refactored `history/history.go`**: Extracted `LoadAllFrom(dir)` and `WriteEntryTo(dir, ...)` so `FileBackend` can use a custom history directory. `LoadAll`/`WriteEntry` remain thin backward-compatible wrappers.
- **Created `backend/file_backend.go`**: A new `Backend` implementation that reads/writes a plain crontab file + temp history directory instead of the system crontab.
- **Added `NewManagerWithBackend`** to `backend/manager.go`: A constructor that accepts any `Backend`, enabling tests to inject `FileBackend`.
- **Added `--cron-file` CLI flag**: When set, uses `FileBackend` instead of system crontab. Useful for testing and dry-run scenarios.
- **8 E2E test cases** in `e2e/tui_test.go` driving the TUI model programmatically via `Update()` calls, asserting on crontab file contents:
  - Create blank job
  - Delete job
  - Toggle disable
  - Toggle re-enable
  - Edit job name
  - Cancel form (esc)
  - Create multiple jobs sequentially
  - Delete second of two jobs

## Test plan
- [x] All 8 E2E tests pass
- [x] All existing unit tests pass (`go test ./...`)
- [x] `go build` and `go vet` clean