### PR TITLE
Feat #13: Add fuzzy search/filter for list panels

### DIFF
--- a/ui/bars.go
+++ b/ui/bars.go
@@ -32,6 +32,8 @@ func renderTopBar(m mode, serverName string, version string, width int) string {
 		modeStr = modeStyle.Render("NEW JOB")
 	case modeTemplatePicker:
 		modeStr = modeStyle.Render("TEMPLATE")
+	case modeSearch:
+		modeStr = modeStyle.Render("SEARCH")
 	}
 
 	leftPart := title + " " + versionTag + "  " + serverTag
@@ -41,7 +43,7 @@ func renderTopBar(m mode, serverName string, version string, width int) string {
 	return topBarStyle.Width(width).Render(bar)
 }
 
-func renderBottomBar(m mode, focusPanel int, statusMsg string, statusKind statusType, width int) string {
+func renderBottomBar(m mode, focusPanel int, statusMsg string, statusKind statusType, width int, searchView string) string {
 	var help string
 	switch m {
 	case modeNormal:
@@ -59,7 +61,8 @@ func renderBottomBar(m mode, focusPanel int, statusMsg string, statusKind status
 		} else if focusPanel == panelHistory {
 			help = helpBinding("D", "delete") + helpSep()
 		}
-		help += helpBinding("?", "help") + helpSep() +
+		help += helpBinding("/", "search") + helpSep() +
+			helpBinding("?", "help") + helpSep() +
 			helpBinding("q", "quit")
 	case modeForm, modeAddServer:
 		help = helpBinding("tab", "next") + helpSep() +
@@ -86,6 +89,10 @@ func renderBottomBar(m mode, focusPanel int, statusMsg string, statusKind status
 		help = helpBinding("↑/↓", "select") + helpSep() +
 			helpBinding("enter", "choose") + helpSep() +
 			helpBinding("esc", "back")
+	case modeSearch:
+		help = helpKeyStyle.Render("/") + " " + searchView + "  " +
+			helpBinding("enter", "accept") + helpSep() +
+			helpBinding("esc", "clear")
 	}
 
 	var status string
@@ -136,6 +143,8 @@ func renderHelpScreen() string {
 		{"p", "Set/change project group"},
 		{"J/K", "Move job up/down (reorder)"},
 		{"", "── General ──"},
+		{"/", "Search/filter current panel"},
+		{"esc", "Clear search filter"},
 		{"1/2/3/4/tab", "Switch panel"},
 		{"R", "Refresh from crontab"},
 		{"u", "Update app to latest version"},

--- a/ui/historylist.go
+++ b/ui/historylist.go
@@ -8,9 +8,30 @@ import (
 	"github.com/swalha1999/lazycron/history"
 )
 
-func renderHistoryList(entries []history.Entry, selected, width, height int, focused bool) string {
+func renderHistoryList(entries []history.Entry, selected, width, height int, focused bool, matchSet map[int]bool) string {
 	if len(entries) == 0 {
 		return mutedItemStyle.Render("\n  No history yet")
+	}
+
+	// Build list of visible indices
+	var visible []int
+	for i := range entries {
+		if matchSet == nil || matchSet[i] {
+			visible = append(visible, i)
+		}
+	}
+
+	if len(visible) == 0 {
+		return mutedItemStyle.Render("\n  No matches")
+	}
+
+	// Find selected position within visible list
+	selPos := 0
+	for j, idx := range visible {
+		if idx == selected {
+			selPos = j
+			break
+		}
 	}
 
 	var b strings.Builder
@@ -20,13 +41,13 @@ func renderHistoryList(entries []history.Entry, selected, width, height int, foc
 		listHeight = 1
 	}
 
-	startIdx := 0
-	if selected >= listHeight {
-		startIdx = selected - listHeight + 1
+	startPos := 0
+	if selPos >= listHeight {
+		startPos = selPos - listHeight + 1
 	}
-	endIdx := startIdx + listHeight
-	if endIdx > len(entries) {
-		endIdx = len(entries)
+	endPos := startPos + listHeight
+	if endPos > len(visible) {
+		endPos = len(visible)
 	}
 
 	maxNameWidth := width - 16
@@ -34,7 +55,8 @@ func renderHistoryList(entries []history.Entry, selected, width, height int, foc
 		maxNameWidth = 8
 	}
 
-	for i := startIdx; i < endIdx; i++ {
+	for p := startPos; p < endPos; p++ {
+		i := visible[p]
 		entry := entries[i]
 
 		name := entry.JobName
@@ -75,13 +97,13 @@ func renderHistoryList(entries []history.Entry, selected, width, height int, foc
 		}
 
 		b.WriteString(line)
-		if i < endIdx-1 {
+		if p < endPos-1 {
 			b.WriteString("\n")
 		}
 	}
 
-	if len(entries) > listHeight {
-		scrollInfo := fmt.Sprintf(" %d/%d", selected+1, len(entries))
+	if len(visible) > listHeight {
+		scrollInfo := fmt.Sprintf(" %d/%d", selPos+1, len(visible))
 		b.WriteString("\n")
 		b.WriteString(mutedItemStyle.Render(scrollInfo))
 	}

--- a/ui/joblist.go
+++ b/ui/joblist.go
@@ -33,13 +33,29 @@ type projectGroup struct {
 
 // buildRows constructs the visual row list from jobs grouped by project.
 // Projects are sorted alphabetically, with the "Ungrouped" section at the bottom.
-func buildRows(jobs []cron.Job, collapsed map[string]bool) []listRow {
+// If matchSet is non-nil, only jobs with indices in matchSet are included.
+func buildRows(jobs []cron.Job, collapsed map[string]bool, matchSet map[int]bool) []listRow {
 	groups := groupByProject(jobs)
 	var rows []listRow
 	for _, g := range groups {
+		if matchSet != nil {
+			hasMatch := false
+			for _, idx := range g.jobIdxs {
+				if matchSet[idx] {
+					hasMatch = true
+					break
+				}
+			}
+			if !hasMatch {
+				continue
+			}
+		}
 		rows = append(rows, listRow{kind: rowHeader, project: g.name})
 		if !collapsed[g.name] {
 			for _, idx := range g.jobIdxs {
+				if matchSet != nil && !matchSet[idx] {
+					continue
+				}
 				rows = append(rows, listRow{kind: rowJob, jobIdx: idx, project: g.name})
 			}
 		}

--- a/ui/model.go
+++ b/ui/model.go
@@ -23,6 +23,7 @@ const (
 	modeTemplatePicker
 	modeConfirmDeleteHistory
 	modeProjectPrompt
+	modeSearch
 )
 
 type statusType int
@@ -89,6 +90,12 @@ type Model struct {
 	selectedRow       int             // visual row index in grouped job list
 	projectInput      textinput.Model // for quick-assign project prompt
 
+	// Search/filter state
+	searchInput textinput.Model
+	searchQuery string       // active filter text
+	searchPanel int          // panel the filter applies to (-1 = none)
+	searchJobMatch map[int]bool // set of matching job indices (nil = all)
+
 	// App version (for self-update)
 	version string
 }
@@ -124,6 +131,7 @@ func NewModel(mgr *backend.Manager, version string) Model {
 		mode:              modeNormal,
 		focusPanel:        panelServers,
 		collapsedProjects: make(map[string]bool),
+		searchPanel:       -1,
 		version:           version,
 	}
 }

--- a/ui/search.go
+++ b/ui/search.go
@@ -1,0 +1,238 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/swalha1999/lazycron/backend"
+	"github.com/swalha1999/lazycron/cron"
+	"github.com/swalha1999/lazycron/history"
+)
+
+func newSearchInput() textinput.Model {
+	ti := textinput.New()
+	ti.Prompt = ""
+	ti.Placeholder = "type to filter..."
+	ti.CharLimit = 128
+	ti.PlaceholderStyle = lipgloss.NewStyle().Foreground(colorMuted)
+	ti.TextStyle = lipgloss.NewStyle().Foreground(colorFg)
+	ti.Cursor.Style = lipgloss.NewStyle().Foreground(colorHighlight)
+	return ti
+}
+
+// enterSearch switches to search mode for the currently focused panel.
+func (m *Model) enterSearch() tea.Cmd {
+	panel := m.focusPanel
+	if panel == panelDetail {
+		panel = m.lastLeftPanel
+	}
+	m.searchInput = newSearchInput()
+	if m.searchPanel == panel && m.searchQuery != "" {
+		m.searchInput.SetValue(m.searchQuery)
+	}
+	m.searchPanel = panel
+	m.mode = modeSearch
+	m.statusMsg = ""
+	return m.searchInput.Focus()
+}
+
+// clearSearch removes the active search filter and restores full lists.
+func (m *Model) clearSearch() {
+	m.searchQuery = ""
+	m.searchPanel = -1
+	m.searchJobMatch = nil
+}
+
+// hasActiveSearch returns true if a search filter is currently applied.
+func (m *Model) hasActiveSearch() bool {
+	return m.searchPanel >= 0 && m.searchQuery != ""
+}
+
+// applySearch recomputes filtered data based on the current search query.
+func (m *Model) applySearch(query string) {
+	m.searchQuery = query
+	if query == "" {
+		m.searchJobMatch = nil
+		return
+	}
+
+	switch m.searchPanel {
+	case panelJobs:
+		m.searchJobMatch = matchJobs(m.jobs, query)
+		m.clampSelectedRow()
+	case panelServers:
+		// Clamp server selection to visible items
+		servers := m.manager.Servers()
+		visible := matchServers(servers, query)
+		if len(visible) > 0 && !visible[m.serverSelected] {
+			for i := 0; i < len(servers); i++ {
+				if visible[i] {
+					m.serverSelected = i
+					break
+				}
+			}
+		}
+	case panelHistory:
+		visible := matchHistory(m.history, query)
+		if len(visible) > 0 && !visible[m.historySelected] {
+			for i := 0; i < len(m.history); i++ {
+				if visible[i] {
+					m.historySelected = i
+					break
+				}
+			}
+		}
+	}
+}
+
+// matchJobs returns a set of job indices that match the query.
+func matchJobs(jobs []cron.Job, query string) map[int]bool {
+	matched := make(map[int]bool)
+	for i, job := range jobs {
+		searchText := strings.ToLower(job.Name + " " + job.Tag + " " + cron.CronToHuman(job.Schedule) + " " + job.Project)
+		if fuzzyMatchSimple(searchText, strings.ToLower(query)) {
+			matched[i] = true
+		}
+	}
+	return matched
+}
+
+// matchServers returns a set of server indices that match the query.
+func matchServers(servers []backend.ServerInfo, query string) map[int]bool {
+	matched := make(map[int]bool)
+	for i, srv := range servers {
+		searchText := strings.ToLower(srv.Name + " " + srv.Host)
+		if fuzzyMatchSimple(searchText, strings.ToLower(query)) {
+			matched[i] = true
+		}
+	}
+	return matched
+}
+
+// matchHistory returns a set of history indices that match the query.
+func matchHistory(entries []history.Entry, query string) map[int]bool {
+	matched := make(map[int]bool)
+	for i, entry := range entries {
+		searchText := strings.ToLower(entry.JobName + " " + entry.Timestamp)
+		if fuzzyMatchSimple(searchText, strings.ToLower(query)) {
+			matched[i] = true
+		}
+	}
+	return matched
+}
+
+// fuzzyMatchSimple does a case-insensitive subsequence match.
+// Both text and pattern should already be lowercased.
+func fuzzyMatchSimple(text, pattern string) bool {
+	pi := 0
+	for ni := 0; ni < len(text) && pi < len(pattern); ni++ {
+		if text[ni] == pattern[pi] {
+			pi++
+		}
+	}
+	return pi >= len(pattern)
+}
+
+// serverMatchSet returns the current match set for servers, or nil if no search is active.
+func (m *Model) serverMatchSet() map[int]bool {
+	if m.searchPanel != panelServers || m.searchQuery == "" {
+		return nil
+	}
+	return matchServers(m.manager.Servers(), m.searchQuery)
+}
+
+// historyMatchSet returns the current match set for history, or nil if no search is active.
+func (m *Model) historyMatchSet() map[int]bool {
+	if m.searchPanel != panelHistory || m.searchQuery == "" {
+		return nil
+	}
+	return matchHistory(m.history, m.searchQuery)
+}
+
+// nextVisibleServer finds the next visible server index in the given direction.
+func (m *Model) nextVisibleServer(from, direction int) int {
+	matchSet := m.serverMatchSet()
+	if matchSet == nil {
+		return from
+	}
+	count := m.manager.ServerCount()
+	for i := from; i >= 0 && i < count; i += direction {
+		if matchSet[i] {
+			return i
+		}
+	}
+	return -1
+}
+
+// nextVisibleHistory finds the next visible history index in the given direction.
+func (m *Model) nextVisibleHistory(from, direction int) int {
+	matchSet := m.historyMatchSet()
+	if matchSet == nil {
+		return from
+	}
+	for i := from; i >= 0 && i < len(m.history); i += direction {
+		if matchSet[i] {
+			return i
+		}
+	}
+	return -1
+}
+
+// visibleServerCount returns (matched, total) counts for servers.
+func (m *Model) visibleServerCount() (int, int) {
+	total := m.manager.ServerCount()
+	matchSet := m.serverMatchSet()
+	if matchSet == nil {
+		return total, total
+	}
+	return len(matchSet), total
+}
+
+// visibleHistoryCount returns (matched, total) counts for history.
+func (m *Model) visibleHistoryCount() (int, int) {
+	total := len(m.history)
+	matchSet := m.historyMatchSet()
+	if matchSet == nil {
+		return total, total
+	}
+	return len(matchSet), total
+}
+
+// visibleJobCount returns (matched, total) counts for jobs.
+func (m *Model) visibleJobCount() (int, int) {
+	total := len(m.jobs)
+	if m.searchJobMatch == nil {
+		return total, total
+	}
+	return len(m.searchJobMatch), total
+}
+
+// handleSearchKey handles key events during search mode.
+func (m Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "enter":
+		// Lock the filter and return to normal mode
+		query := strings.TrimSpace(m.searchInput.Value())
+		if query == "" {
+			m.clearSearch()
+		} else {
+			m.searchQuery = query
+			m.applySearch(query)
+		}
+		m.mode = modeNormal
+		return m, nil
+	case "esc":
+		// Clear filter and return to normal mode
+		m.clearSearch()
+		m.mode = modeNormal
+		return m, nil
+	default:
+		var cmd tea.Cmd
+		m.searchInput, cmd = m.searchInput.Update(msg)
+		// Apply filter in real-time
+		m.applySearch(m.searchInput.Value())
+		return m, cmd
+	}
+}

--- a/ui/serverlist.go
+++ b/ui/serverlist.go
@@ -7,25 +7,47 @@ import (
 	"github.com/swalha1999/lazycron/backend"
 )
 
-func renderServerList(servers []backend.ServerInfo, selected, activeIdx, width, height int, focused bool) string {
+func renderServerList(servers []backend.ServerInfo, selected, activeIdx, width, height int, focused bool, matchSet map[int]bool) string {
 	if len(servers) == 0 {
 		return mutedItemStyle.Render("No servers")
+	}
+
+	// Build list of visible indices
+	var visible []int
+	for i := range servers {
+		if matchSet == nil || matchSet[i] {
+			visible = append(visible, i)
+		}
+	}
+
+	if len(visible) == 0 {
+		return mutedItemStyle.Render("No matches")
+	}
+
+	// Find selected position within visible list
+	selPos := 0
+	for j, idx := range visible {
+		if idx == selected {
+			selPos = j
+			break
+		}
 	}
 
 	var b strings.Builder
 
 	visibleHeight := height
-	startIdx := 0
-	if selected >= visibleHeight {
-		startIdx = selected - visibleHeight + 1
+	startPos := 0
+	if selPos >= visibleHeight {
+		startPos = selPos - visibleHeight + 1
 	}
 
-	endIdx := startIdx + visibleHeight
-	if endIdx > len(servers) {
-		endIdx = len(servers)
+	endPos := startPos + visibleHeight
+	if endPos > len(visible) {
+		endPos = len(visible)
 	}
 
-	for i := startIdx; i < endIdx; i++ {
+	for p := startPos; p < endPos; p++ {
+		i := visible[p]
 		srv := servers[i]
 		isSelected := i == selected
 		isActive := i == activeIdx
@@ -62,14 +84,14 @@ func renderServerList(servers []backend.ServerInfo, selected, activeIdx, width, 
 		}
 
 		b.WriteString(line)
-		if i < endIdx-1 {
+		if p < endPos-1 {
 			b.WriteString("\n")
 		}
 	}
 
 	// Scroll indicator
-	if len(servers) > visibleHeight {
-		scrollInfo := fmt.Sprintf(" [%d/%d]", selected+1, len(servers))
+	if len(visible) > visibleHeight {
+		scrollInfo := fmt.Sprintf(" [%d/%d]", selPos+1, len(visible))
 		b.WriteString("\n" + mutedItemStyle.Render(scrollInfo))
 	}
 

--- a/ui/update.go
+++ b/ui/update.go
@@ -233,6 +233,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var cmd tea.Cmd
 		m.projectInput, cmd = m.projectInput.Update(msg)
 		return m, cmd
+	case modeSearch:
+		var cmd tea.Cmd
+		m.searchInput, cmd = m.searchInput.Update(msg)
+		return m, cmd
 	case modeTemplatePicker:
 		if m.templatePicker.phase == phaseVariables && len(m.templatePicker.variableInputs) > 0 {
 			idx := m.templatePicker.activeVariable
@@ -272,6 +276,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleTemplatePickerKey(msg)
 	case modeProjectPrompt:
 		return m.handleProjectPromptKey(msg)
+	case modeSearch:
+		return m.handleSearchKey(msg)
 	default:
 		return m.handleNormalKey(msg)
 	}

--- a/ui/update_dialogs.go
+++ b/ui/update_dialogs.go
@@ -124,7 +124,7 @@ func (m Model) handleProjectPromptKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.statusKind = statusSuccess
 			m.statusID++
 			// Rebuild rows and move selection to follow the job
-			rows := buildRows(m.jobs, m.collapsedProjects)
+			rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 			m.selectedRow = rowForJobIdx(rows, jobIdx)
 			b := m.manager.ActiveBackend()
 			return m, tea.Batch(saveJobs(b, m.jobs), clearStatusAfter(m.statusID, 4*time.Second))

--- a/ui/update_form.go
+++ b/ui/update_form.go
@@ -118,13 +118,13 @@ func (m Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			job.Enabled = m.jobs[m.form.editIndex].Enabled
 			m.jobs[m.form.editIndex] = job
 			// Re-position selection to follow the job (project may have changed)
-			rows := buildRows(m.jobs, m.collapsedProjects)
+			rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 			m.selectedRow = rowForJobIdx(rows, m.form.editIndex)
 			m.statusMsg = fmt.Sprintf("Updated job '%s'", job.Name)
 		} else {
 			m.jobs = append(m.jobs, job)
 			// Point selectedRow to the new job's visual row
-			rows := buildRows(m.jobs, m.collapsedProjects)
+			rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 			m.selectedRow = rowForJobIdx(rows, len(m.jobs)-1)
 			m.statusMsg = fmt.Sprintf("Created job '%s'", job.Name)
 		}

--- a/ui/update_normal.go
+++ b/ui/update_normal.go
@@ -10,7 +10,7 @@ import (
 
 // currentJobIndex returns the job index for the current selectedRow, or -1 if on a header.
 func (m *Model) currentJobIndex() int {
-	rows := buildRows(m.jobs, m.collapsedProjects)
+	rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 	if m.selectedRow < 0 || m.selectedRow >= len(rows) {
 		return -1
 	}
@@ -22,7 +22,7 @@ func (m *Model) currentJobIndex() int {
 
 // isOnHeader returns true if the current selectedRow is a group header.
 func (m *Model) isOnHeader() bool {
-	rows := buildRows(m.jobs, m.collapsedProjects)
+	rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 	if m.selectedRow < 0 || m.selectedRow >= len(rows) {
 		return false
 	}
@@ -31,7 +31,7 @@ func (m *Model) isOnHeader() bool {
 
 // toggleCurrentHeader toggles the collapse state of the header at selectedRow.
 func (m *Model) toggleCurrentHeader() {
-	rows := buildRows(m.jobs, m.collapsedProjects)
+	rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 	if m.selectedRow < 0 || m.selectedRow >= len(rows) {
 		return
 	}
@@ -43,7 +43,7 @@ func (m *Model) toggleCurrentHeader() {
 
 // clampSelectedRow ensures selectedRow is within bounds of current rows.
 func (m *Model) clampSelectedRow() {
-	rows := buildRows(m.jobs, m.collapsedProjects)
+	rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 	if len(rows) == 0 {
 		m.selectedRow = 0
 		return
@@ -91,19 +91,19 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "up", "k":
 		switch m.focusPanel {
 		case panelServers:
-			if m.serverSelected > 0 {
-				m.serverSelected--
+			if next := m.nextVisibleServer(m.serverSelected-1, -1); next >= 0 {
+				m.serverSelected = next
 			}
 		case panelJobs:
-			rows := buildRows(m.jobs, m.collapsedProjects)
+			rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 			if m.selectedRow > 0 {
 				m.selectedRow--
 				m.detailScroll = 0
 			}
 			_ = rows
 		case panelHistory:
-			if m.historySelected > 0 {
-				m.historySelected--
+			if next := m.nextVisibleHistory(m.historySelected-1, -1); next >= 0 {
+				m.historySelected = next
 				m.detailScroll = 0
 			}
 		case panelDetail:
@@ -115,18 +115,18 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "down", "j":
 		switch m.focusPanel {
 		case panelServers:
-			if m.serverSelected < m.manager.ServerCount()-1 {
-				m.serverSelected++
+			if next := m.nextVisibleServer(m.serverSelected+1, +1); next >= 0 {
+				m.serverSelected = next
 			}
 		case panelJobs:
-			rows := buildRows(m.jobs, m.collapsedProjects)
+			rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 			if m.selectedRow < len(rows)-1 {
 				m.selectedRow++
 				m.detailScroll = 0
 			}
 		case panelHistory:
-			if m.historySelected < len(m.history)-1 {
-				m.historySelected++
+			if next := m.nextVisibleHistory(m.historySelected+1, +1); next >= 0 {
+				m.historySelected = next
 				m.detailScroll = 0
 			}
 		case panelDetail:
@@ -140,7 +140,7 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				swapIdx := findSiblingJob(m.jobs, jobIdx, -1)
 				if swapIdx >= 0 {
 					m.jobs[jobIdx], m.jobs[swapIdx] = m.jobs[swapIdx], m.jobs[jobIdx]
-					rows := buildRows(m.jobs, m.collapsedProjects)
+					rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 					m.selectedRow = rowForJobIdx(rows, swapIdx)
 					m.statusMsg = fmt.Sprintf("Moved '%s' up", m.jobs[swapIdx].Name)
 					m.statusKind = statusInfo
@@ -158,7 +158,7 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				swapIdx := findSiblingJob(m.jobs, jobIdx, +1)
 				if swapIdx >= 0 {
 					m.jobs[jobIdx], m.jobs[swapIdx] = m.jobs[swapIdx], m.jobs[jobIdx]
-					rows := buildRows(m.jobs, m.collapsedProjects)
+					rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 					m.selectedRow = rowForJobIdx(rows, swapIdx)
 					m.statusMsg = fmt.Sprintf("Moved '%s' down", m.jobs[swapIdx].Name)
 					m.statusKind = statusInfo
@@ -343,6 +343,7 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case "R":
+		m.clearSearch()
 		m.statusMsg = "Refreshing..."
 		m.statusKind = statusInfo
 		b := m.manager.ActiveBackend()
@@ -356,6 +357,17 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "?":
 		m.mode = modeHelp
 		m.statusMsg = ""
+
+	case "/":
+		if m.focusPanel != panelDetail {
+			return m, m.enterSearch()
+		}
+
+	case "esc":
+		if m.hasActiveSearch() {
+			m.clearSearch()
+			return m, nil
+		}
 	}
 	return m, nil
 }
@@ -364,6 +376,7 @@ func (m Model) switchToServer(index int) (tea.Model, tea.Cmd) {
 	if index == m.manager.ActiveIndex() {
 		return m, nil
 	}
+	m.clearSearch()
 
 	info := m.manager.ServerAt(index)
 

--- a/ui/view.go
+++ b/ui/view.go
@@ -19,7 +19,11 @@ func (m Model) View() string {
 	serverName := m.manager.ServerAt(m.manager.ActiveIndex()).Name
 	topBar := renderTopBar(m.mode, serverName, m.version, m.width)
 
-	bottomBar := renderBottomBar(m.mode, m.focusPanel, m.statusMsg, m.statusKind, m.width)
+	var searchView string
+	if m.mode == modeSearch {
+		searchView = m.searchInput.View()
+	}
+	bottomBar := renderBottomBar(m.mode, m.focusPanel, m.statusMsg, m.statusKind, m.width, searchView)
 
 	contentHeight := m.height - 1 - lipgloss.Height(bottomBar)
 
@@ -144,7 +148,8 @@ func (m Model) renderPanels(height int) string {
 
 	// [1] Servers panel
 	servers := m.manager.Servers()
-	serverContent := renderServerList(servers, m.serverSelected, m.manager.ActiveIndex(), listWidth-4, serverInnerHeight, m.focusPanel == panelServers)
+	srvMatchSet := m.serverMatchSet()
+	serverContent := renderServerList(servers, m.serverSelected, m.manager.ActiveIndex(), listWidth-4, serverInnerHeight, m.focusPanel == panelServers, srvMatchSet)
 	serversActive := m.focusPanel == panelServers
 	serversPanelStyle := panelStyle
 	if serversActive {
@@ -154,10 +159,14 @@ func (m Model) renderPanels(height int) string {
 		Width(listWidth).
 		Height(serverInnerHeight).
 		Render(serverContent)
-	serversBox = injectBorderTitle(serversBox, "1", "Servers", serversActive)
+	serversTitle := "Servers"
+	if matched, total := m.visibleServerCount(); matched != total {
+		serversTitle = fmt.Sprintf("Servers %d/%d", matched, total)
+	}
+	serversBox = injectBorderTitle(serversBox, "1", serversTitle, serversActive)
 
 	// [2] Jobs panel
-	rows := buildRows(m.jobs, m.collapsedProjects)
+	rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 	listContent := renderJobList(m.jobs, m.selectedRow, rows, listWidth-4, jobsHeight, m.collapsedProjects)
 	jobsActive := m.focusPanel == panelJobs
 	jobsPanelStyle := panelStyle
@@ -168,10 +177,15 @@ func (m Model) renderPanels(height int) string {
 		Width(listWidth).
 		Height(jobsHeight).
 		Render(listContent)
-	jobsBox = injectBorderTitle(jobsBox, "2", "Jobs", jobsActive)
+	jobsTitle := "Jobs"
+	if matched, total := m.visibleJobCount(); matched != total {
+		jobsTitle = fmt.Sprintf("Jobs %d/%d", matched, total)
+	}
+	jobsBox = injectBorderTitle(jobsBox, "2", jobsTitle, jobsActive)
 
 	// [3] History panel
-	historyContent := renderHistoryList(m.history, m.historySelected, listWidth-4, historyHeight, m.focusPanel == panelHistory)
+	histMatchSet := m.historyMatchSet()
+	historyContent := renderHistoryList(m.history, m.historySelected, listWidth-4, historyHeight, m.focusPanel == panelHistory, histMatchSet)
 	historyActive := m.focusPanel == panelHistory
 	historyPanelStyle := panelStyle
 	if historyActive {
@@ -181,7 +195,11 @@ func (m Model) renderPanels(height int) string {
 		Width(listWidth).
 		Height(historyHeight).
 		Render(historyContent)
-	historyBox = injectBorderTitle(historyBox, "3", "History", historyActive)
+	historyTitle := "History"
+	if matched, total := m.visibleHistoryCount(); matched != total {
+		historyTitle = fmt.Sprintf("History %d/%d", matched, total)
+	}
+	historyBox = injectBorderTitle(historyBox, "3", historyTitle, historyActive)
 
 	leftPanel := lipgloss.JoinVertical(lipgloss.Left, serversBox, jobsBox, historyBox)
 
@@ -223,7 +241,7 @@ func (m Model) buildDetailContent(width int) string {
 // selectedJobIndex returns the job index for the current visual row,
 // or -1 if on a header row or no jobs exist.
 func (m Model) selectedJobIndex() int {
-	rows := buildRows(m.jobs, m.collapsedProjects)
+	rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 	if m.selectedRow < 0 || m.selectedRow >= len(rows) {
 		return -1
 	}


### PR DESCRIPTION
Closes #13

## Summary
- Adds `/` keybinding to activate fuzzy search mode in Jobs, Servers, and History panels
- Real-time fuzzy (subsequence) filtering as you type, case-insensitive
- `Enter` locks the current filter for navigating within results; `Escape` clears it
- Panel titles show filtered counts when a filter is active (e.g. "Jobs 3/15")
- Search keybinding documented in `?` help screen and bottom bar
- Navigation (j/k) respects filtered results for servers and history panels
- Search filter auto-clears on server switch or manual refresh (R)

## Changes
- **`ui/search.go`** (new): Search state management, fuzzy matching, key handling
- **`ui/model.go`**: Added `modeSearch` mode and search state fields
- **`ui/joblist.go`**: `buildRows` accepts optional match set to filter jobs while preserving original indices
- **`ui/serverlist.go`**: `renderServerList` filters by match set
- **`ui/historylist.go`**: `renderHistoryList` filters by match set
- **`ui/update.go`**: Dispatch for search mode messages
- **`ui/update_normal.go`**: `/` and `esc` keybindings, filtered navigation for servers/history
- **`ui/bars.go`**: Search mode in top bar, search input in bottom bar, help screen entry
- **`ui/view.go`**: Filtered count in panel titles, pass match sets to renderers

## Test plan
- [ ] Press `/` in Jobs panel → search input appears in bottom bar, top bar shows SEARCH mode
- [ ] Type a query → jobs list filters in real-time (fuzzy match on name, tag, schedule, project)
- [ ] Press `Enter` → filter locks, can navigate within filtered results
- [ ] Press `Escape` → filter clears, full list restored
- [ ] Repeat for Servers and History panels
- [ ] Panel title shows "Jobs 3/15" style count when filter is active
- [ ] `?` help screen shows `/` keybinding
- [ ] Switching servers clears the active filter
- [ ] Build passes (`go build ./...`), tests pass (`go test ./...`), vet clean (`go vet ./...`)