### PR TITLE
Refactor #18: Extract duplicated logic from RemoteBackend into shared packages

### DIFF
--- a/backend/remote.go
+++ b/backend/remote.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/swalha1999/lazycron/cron"
 	"github.com/swalha1999/lazycron/history"
@@ -68,12 +67,7 @@ func (b *RemoteBackend) ReadJobs() ([]cron.Job, error) {
 			path := strings.Trim(strings.TrimPrefix(j.Command, "sh "), "'\"")
 			data, readErr := b.client.ReadFile(path)
 			if readErr == nil {
-				content := string(data)
-				if strings.HasPrefix(content, "#!/bin/sh\n") {
-					content = content[len("#!/bin/sh\n"):]
-				}
-				content = strings.TrimPrefix(content, cron.ScriptPreamble)
-				jobs[i].Command = strings.TrimRight(content, "\n")
+				jobs[i].Command = cron.StripShebang(string(data))
 			}
 		}
 	}
@@ -99,7 +93,7 @@ func (b *RemoteBackend) WriteJobs(jobs []cron.Job) error {
 	for _, j := range jobs {
 		filename := filepath.Base(cron.ScriptPath(j.Name))
 		active[filename] = true
-		content := "#!/bin/sh\n" + cron.ScriptPreamble + j.Command + "\n"
+		content := cron.BuildScriptContent(j.Command)
 		path := remoteScriptsDir + "/" + filename
 		if err := b.client.Upload(content, path, 0o755); err != nil {
 			return fmt.Errorf("upload script %s: %w", j.Name, err)
@@ -137,8 +131,7 @@ func (b *RemoteBackend) RunJob(name, command string) (string, error) {
 	scriptPath := lcDir + "/scripts/" + filepath.Base(cron.ScriptPath(name))
 
 	// Upload script to remote.
-	content := "#!/bin/sh\n" + cron.ScriptPreamble + command + "\n"
-	if err := b.client.Upload(content, scriptPath, 0o755); err != nil {
+	if err := b.client.Upload(cron.BuildScriptContent(command), scriptPath, 0o755); err != nil {
 		return "", fmt.Errorf("upload script: %w", err)
 	}
 
@@ -183,15 +176,7 @@ func (b *RemoteBackend) LoadHistory() ([]history.Entry, error) {
 }
 
 func (b *RemoteBackend) WriteHistory(jobName, output string, success bool) error {
-	now := time.Now()
-	e := record.Entry{
-		JobName:   jobName,
-		Timestamp: now.Format(time.RFC3339),
-		Output:    output,
-		Success:   &success,
-	}
-
-	data, err := json.MarshalIndent(e, "", "  ")
+	filename, data, err := history.BuildHistoryFile(jobName, output, success)
 	if err != nil {
 		return err
 	}
@@ -201,12 +186,7 @@ func (b *RemoteBackend) WriteHistory(jobName, output string, success bool) error
 		return lcErr
 	}
 
-	safeName := strings.ReplaceAll(jobName, "/", "_")
-	safeName = strings.ReplaceAll(safeName, " ", "_")
-	filename := now.Format("2006-01-02T15-04-05") + "_" + safeName + ".json"
-	path := lcDir + "/history/" + filename
-
-	return b.client.Upload(string(data), path, 0o644)
+	return b.client.Upload(string(data), lcDir+"/history/"+filename, 0o644)
 }
 
 func (b *RemoteBackend) DeleteHistory(filePath string) error {

--- a/cron/scripts.go
+++ b/cron/scripts.go
@@ -37,8 +37,7 @@ func WriteScript(jobName, command string) error {
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
-	content := "#!/bin/sh\n" + ScriptPreamble + command + "\n"
-	return os.WriteFile(ScriptPath(jobName), []byte(content), 0700)
+	return os.WriteFile(ScriptPath(jobName), []byte(BuildScriptContent(command)), 0700)
 }
 
 // ScriptPreamble is the profile-sourcing block prepended to every script.
@@ -48,6 +47,21 @@ const ScriptPreamble = "# Source user profile for PATH and environment variables
 	"done\n" +
 	"unset __lc_rc\n"
 
+// BuildScriptContent returns a complete script with shebang, preamble, and command.
+func BuildScriptContent(command string) string {
+	return "#!/bin/sh\n" + ScriptPreamble + command + "\n"
+}
+
+// StripShebang removes the shebang line and preamble from script content,
+// returning just the command.
+func StripShebang(content string) string {
+	if strings.HasPrefix(content, "#!/bin/sh\n") {
+		content = content[len("#!/bin/sh\n"):]
+	}
+	content = strings.TrimPrefix(content, ScriptPreamble)
+	return strings.TrimRight(content, "\n")
+}
+
 // ReadScriptCommand reads a script file and returns the command
 // (stripping the shebang and profile-sourcing preamble).
 func ReadScriptCommand(path string) (string, error) {
@@ -55,12 +69,7 @@ func ReadScriptCommand(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	content := string(data)
-	if strings.HasPrefix(content, "#!/bin/sh\n") {
-		content = content[len("#!/bin/sh\n"):]
-	}
-	content = strings.TrimPrefix(content, ScriptPreamble)
-	return strings.TrimRight(content, "\n"), nil
+	return StripShebang(string(data)), nil
 }
 
 // DeleteScript removes a job's script file.

--- a/history/history.go
+++ b/history/history.go
@@ -71,8 +71,8 @@ func WriteEntry(jobName, output string, success bool) error {
 	return WriteEntryTo(record.HistoryDir(), jobName, output, success)
 }
 
-// WriteEntryTo writes a history entry to the given directory.
-func WriteEntryTo(dir, jobName, output string, success bool) error {
+// BuildHistoryFile creates the filename and JSON data for a history entry.
+func BuildHistoryFile(jobName, output string, success bool) (filename string, data []byte, err error) {
 	now := time.Now()
 	e := record.Entry{
 		JobName:   jobName,
@@ -81,15 +81,22 @@ func WriteEntryTo(dir, jobName, output string, success bool) error {
 		Success:   &success,
 	}
 
-	data, err := json.MarshalIndent(e, "", "  ")
+	data, err = json.MarshalIndent(e, "", "  ")
 	if err != nil {
-		return err
+		return "", nil, err
 	}
 
 	safeName := strings.ReplaceAll(jobName, "/", "_")
 	safeName = strings.ReplaceAll(safeName, " ", "_")
-	filename := now.Format("2006-01-02T15-04-05") + "_" + safeName + ".json"
-	path := filepath.Join(dir, filename)
+	filename = now.Format("2006-01-02T15-04-05") + "_" + safeName + ".json"
+	return filename, data, nil
+}
 
-	return os.WriteFile(path, data, 0o600)
+// WriteEntryTo writes a history entry to the given directory.
+func WriteEntryTo(dir, jobName, output string, success bool) error {
+	filename, data, err := BuildHistoryFile(jobName, output, success)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, filename), data, 0o600)
 }


### PR DESCRIPTION
Closes #18

## What
- Extracted `cron.StripShebang()` — shared helper that strips `#!/bin/sh\n` and the preamble from script content
- Extracted `cron.BuildScriptContent()` — builds complete script string (`#!/bin/sh\n` + preamble + command), replacing 3 inline copies
- Extracted `history.BuildHistoryFile()` — creates the history entry JSON and filename, replacing duplicated logic in `history.WriteEntryTo()` and `remote.WriteHistory()`
- Updated `RemoteBackend` to delegate to these shared helpers, matching the pattern already used by `LocalBackend`

## Why
- Eliminates DRY violations: history entry creation, shebang stripping, and script content building were each duplicated between `RemoteBackend` and the shared packages
- Changes to history JSON format, filename scheme, or script format now only need to be updated in one place
- `RemoteBackend` now follows the same delegation pattern as `LocalBackend`, improving consistency and maintainability