### PR TITLE
Fix #27: Shell-quote working directory in command construction

### DIFF
--- a/backend/remote.go
+++ b/backend/remote.go
@@ -224,7 +224,5 @@ func (b *RemoteBackend) Close() error {
 	return b.client.Close()
 }
 
-// shellQuote wraps a string in single quotes with proper escaping.
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
-}
+// shellQuote is a package-level alias for cron.ShellQuote.
+var shellQuote = cron.ShellQuote

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -61,7 +61,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 	finalCmd := addCommand
 	if addWorkDir != "" {
-		finalCmd = fmt.Sprintf("cd %s && %s", addWorkDir, addCommand)
+		finalCmd = fmt.Sprintf("cd %s && %s", cron.ShellQuote(addWorkDir), addCommand)
 	}
 
 	job := cron.Job{

--- a/cron/scripts.go
+++ b/cron/scripts.go
@@ -102,6 +102,12 @@ func SyncScripts(jobs []Job) error {
 	return nil
 }
 
+// ShellQuote wraps a string in single quotes with proper escaping,
+// making it safe to embed in a shell command.
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
 // scriptRefMarker is the path component that identifies a lazycron script reference.
 var scriptRefMarker = filepath.Join(".lazycron", "scripts")
 

--- a/ui/form.go
+++ b/ui/form.go
@@ -202,7 +202,7 @@ func (f *formModel) buildJob() (cron.Job, error) {
 
 	finalCmd := command
 	if workDir != "" {
-		finalCmd = fmt.Sprintf("cd %s && %s", workDir, finalCmd)
+		finalCmd = fmt.Sprintf("cd %s && %s", cron.ShellQuote(workDir), finalCmd)
 	}
 
 	id := f.id


### PR DESCRIPTION
Closes #27

## Summary
- Added `ShellQuote()` to the `cron` package (exported, reusable)
- Applied it to working directory interpolation in `cmd/add.go` and `ui/form.go`
- Replaced the duplicate local `shellQuote` in `backend/remote.go` with an alias to `cron.ShellQuote`

## What was wrong
The working directory was interpolated directly into `cd %s && ...` shell commands without quoting. Paths containing shell metacharacters (`;`, `&&`, `|`, spaces) would be interpreted by the shell, enabling command injection or silently breaking `cd` for paths with spaces.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `go vet ./...` passes
- [x] Existing `shellQuote` tests in `backend/manager_test.go` continue to pass (same logic)