### PR TITLE
Feat #14: Show live next-run preview in job form

### DIFF
--- a/ui/form.go
+++ b/ui/form.go
@@ -170,6 +170,41 @@ func (f *formModel) updateInput(msg tea.Msg) tea.Cmd {
 	return cmd
 }
 
+// nextRunPreview returns a rendered preview of the next run times for the current schedule.
+func (f *formModel) nextRunPreview() string {
+	schedule := strings.TrimSpace(f.inputs[fieldSchedule].Value())
+	if schedule == "" {
+		return ""
+	}
+
+	if f.oneShot {
+		_, resolved, err := cron.DatetimeToCron(schedule)
+		if err != nil {
+			return mutedItemStyle.Render("  ↳ Invalid schedule")
+		}
+		timeStr := resolved.Format("Mon Jan 02, 2006 at 3:04 PM")
+		return mutedItemStyle.Render("  ↳ Scheduled: ") + detailValueStyle.Render(timeStr)
+	}
+
+	cronExpr := cron.HumanToCron(schedule)
+	if err := cron.ValidateCron(cronExpr); err != nil {
+		return mutedItemStyle.Render("  ↳ Invalid schedule")
+	}
+
+	nextRuns := cron.NextRuns(cronExpr, 3)
+	if len(nextRuns) == 0 {
+		return mutedItemStyle.Render("  ↳ No upcoming runs")
+	}
+
+	var b strings.Builder
+	b.WriteString(mutedItemStyle.Render("  ↳ Next:"))
+	for _, t := range nextRuns {
+		timeStr := t.Format("Mon Jan 02, 2006 at 3:04 PM")
+		b.WriteString("\n" + "          " + detailValueStyle.Render(timeStr))
+	}
+	return b.String()
+}
+
 func (f *formModel) buildJob() (cron.Job, error) {
 	name := strings.TrimSpace(f.inputs[fieldName].Value())
 	command := strings.TrimSpace(f.inputs[fieldCommand].Value())
@@ -273,6 +308,13 @@ func renderForm(f *formModel, width int) string {
 		if i == fieldSchedule && !f.oneShot {
 			b.WriteString(renderPicker(&f.picker, inputWidth))
 			b.WriteString("\n")
+		}
+
+		if i == fieldSchedule {
+			if preview := f.nextRunPreview(); preview != "" {
+				b.WriteString(preview)
+				b.WriteString("\n")
+			}
 		}
 
 		if i == fieldWorkDir && f.completer.active {


### PR DESCRIPTION
Closes #14

## Summary
- Adds a `nextRunPreview()` method to the form model that computes and renders a live preview of upcoming run times as the user types or modifies the schedule
- For **recurring jobs**: displays the next 3 run times below the cron picker (e.g. `↳ Next: Mon Mar 30, 2026 at 8:30 AM`)
- For **one-shot jobs**: displays the single scheduled datetime (e.g. `↳ Scheduled: Tue Mar 25, 2026 at 3:00 PM`)
- Shows `↳ Invalid schedule` hint when the expression is empty or invalid
- Leverages the existing `cron.NextRuns()`, `cron.HumanToCron()`, and `cron.DatetimeToCron()` functions — no new dependencies
- Preview updates reactively on every render (same pattern as the detail panel), keeping the form snappy without needing explicit debounce

## Test plan
- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [x] `go vet ./...` clean
- [ ] Manual: create a new recurring job, type `every monday at 8:30am` — verify 3 next-run times appear below the picker
- [ ] Manual: edit the schedule via the visual picker — verify preview updates in real time
- [ ] Manual: toggle one-shot mode (`ctrl+o`), type `tomorrow at 3pm` — verify single datetime preview appears
- [ ] Manual: type an invalid schedule — verify `↳ Invalid schedule` hint appears
- [ ] Manual: clear the schedule field — verify no preview is shown