### PR TITLE
Refactor #20: Extract status-message boilerplate into setStatus helper

### DIFF
--- a/ui/model.go
+++ b/ui/model.go
@@ -1,7 +1,10 @@
 package ui
 
 import (
+	"time"
+
 	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/swalha1999/lazycron/backend"
 	"github.com/swalha1999/lazycron/cron"
@@ -99,6 +102,14 @@ type Model struct {
 
 	// App version (for self-update)
 	version string
+}
+
+// setStatus updates the status bar and returns a Cmd that clears it after d.
+func (m *Model) setStatus(msg string, kind statusType, d time.Duration) tea.Cmd {
+	m.statusMsg = msg
+	m.statusKind = kind
+	m.statusID++
+	return clearStatusAfter(m.statusID, d)
 }
 
 func newPasswordInput() textinput.Model {

--- a/ui/update.go
+++ b/ui/update.go
@@ -25,18 +25,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case jobsLoadedMsg:
 		if msg.err != nil {
-			m.statusMsg = msg.err.Error()
-			m.statusKind = statusError
-			m.statusID++
-			return m, clearStatusAfter(m.statusID, 5*time.Second)
+			return m, m.setStatus(msg.err.Error(), statusError, 5*time.Second)
 		}
 		m.jobs = msg.jobs
 		cmds := []tea.Cmd{}
 		if len(m.jobs) > 0 {
-			m.statusMsg = fmt.Sprintf("Loaded %d job(s)", len(m.jobs))
-			m.statusKind = statusInfo
-			m.statusID++
-			cmds = append(cmds, clearStatusAfter(m.statusID, 2*time.Second))
+			cmds = append(cmds, m.setStatus(fmt.Sprintf("Loaded %d job(s)", len(m.jobs)), statusInfo, 2*time.Second))
 		}
 		// Auto-disable completed one-shot jobs (backup for record.sh)
 		if len(m.jobs) > 0 && len(m.history) > 0 {
@@ -46,10 +40,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case jobSavedMsg:
 		if msg.err != nil {
-			m.statusMsg = "Save failed: " + msg.err.Error()
-			m.statusKind = statusError
-			m.statusID++
-			return m, clearStatusAfter(m.statusID, 5*time.Second)
+			return m, m.setStatus("Save failed: "+msg.err.Error(), statusError, 5*time.Second)
 		}
 		m.manager.InvalidateCache(m.manager.ActiveIndex())
 		return m, nil
@@ -70,10 +61,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case disableCompletedOneShotsMsg:
 		if msg.err != nil {
-			m.statusMsg = "Auto-disable failed: " + msg.err.Error()
-			m.statusKind = statusError
-			m.statusID++
-			return m, clearStatusAfter(m.statusID, 5*time.Second)
+			return m, m.setStatus("Auto-disable failed: "+msg.err.Error(), statusError, 5*time.Second)
 		}
 		if msg.disabled > 0 {
 			// Reload jobs to reflect the changes
@@ -91,15 +79,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case historyDeletedMsg:
 		if msg.err != nil {
-			m.statusMsg = fmt.Sprintf("Failed to delete history: %v", msg.err)
-			m.statusKind = statusError
-			m.statusID++
-			return m, clearStatusAfter(m.statusID, 4*time.Second)
+			return m, m.setStatus(fmt.Sprintf("Failed to delete history: %v", msg.err), statusError, 4*time.Second)
 		}
 		return m, nil
 
 	case jobRanMsg:
-		m.statusID++
 		output := msg.output
 		if output == "" && msg.err != nil {
 			output = msg.err.Error()
@@ -129,9 +113,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusMsg = ""
 			return m, saveCmd
 		}
-		m.statusMsg = fmt.Sprintf("Job '%s' ran successfully", msg.name)
-		m.statusKind = statusSuccess
-		return m, tea.Batch(saveCmd, clearStatusAfter(m.statusID, 4*time.Second))
+		return m, tea.Batch(saveCmd, m.setStatus(fmt.Sprintf("Job '%s' ran successfully", msg.name), statusSuccess, 4*time.Second))
 
 	case serverConnectedMsg:
 		if msg.err != nil {
@@ -146,20 +128,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.statusKind = statusInfo
 				return m, m.passwordInput.Focus()
 			}
-			m.statusMsg = fmt.Sprintf("Connection failed: %s", msg.err)
-			m.statusKind = statusError
-			m.statusID++
-			return m, clearStatusAfter(m.statusID, 5*time.Second)
+			return m, m.setStatus(fmt.Sprintf("Connection failed: %s", msg.err), statusError, 5*time.Second)
 		}
 		return m, loadServerData(m.manager, msg.index)
 
 	case serverDataLoadedMsg:
 		m.serverSwitching = false
 		if msg.err != nil {
-			m.statusMsg = fmt.Sprintf("Failed to load data: %s", msg.err)
-			m.statusKind = statusError
-			m.statusID++
-			return m, clearStatusAfter(m.statusID, 5*time.Second)
+			return m, m.setStatus(fmt.Sprintf("Failed to load data: %s", msg.err), statusError, 5*time.Second)
 		}
 		m.manager.SetCache(msg.index, &backend.CachedData{
 			Jobs:      msg.jobs,
@@ -173,44 +149,29 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.selectedRow = 0
 			m.historySelected = 0
 			serverName := m.manager.ServerAt(msg.index).Name
-			m.statusMsg = fmt.Sprintf("Switched to %s", serverName)
-			m.statusKind = statusSuccess
-			m.statusID++
-			return m, clearStatusAfter(m.statusID, 3*time.Second)
+			return m, m.setStatus(fmt.Sprintf("Switched to %s", serverName), statusSuccess, 3*time.Second)
 		}
 		return m, nil
 
 	case selfUpdateMsg:
-		m.statusID++
 		if msg.err != nil {
-			m.statusMsg = "Update failed: " + msg.err.Error()
-			m.statusKind = statusError
-			return m, clearStatusAfter(m.statusID, 5*time.Second)
+			return m, m.setStatus("Update failed: "+msg.err.Error(), statusError, 5*time.Second)
 		}
 		if msg.newVersion == "" {
-			m.statusMsg = "Already on the latest version"
-			m.statusKind = statusSuccess
-			return m, clearStatusAfter(m.statusID, 3*time.Second)
+			return m, m.setStatus("Already on the latest version", statusSuccess, 3*time.Second)
 		}
 		if msg.needsSudo {
 			m.statusMsg = "Need sudo to install — enter your password..."
 			m.statusKind = statusInfo
 			return m, sudoInstall(msg.newVersion, msg.tmpBinary, msg.targetPath)
 		}
-		m.statusMsg = fmt.Sprintf("Updated to %s — restart lazycron to use the new version", msg.newVersion)
-		m.statusKind = statusSuccess
-		return m, clearStatusAfter(m.statusID, 8*time.Second)
+		return m, m.setStatus(fmt.Sprintf("Updated to %s — restart lazycron to use the new version", msg.newVersion), statusSuccess, 8*time.Second)
 
 	case selfUpdateSudoMsg:
-		m.statusID++
 		if msg.err != nil {
-			m.statusMsg = "Update failed: " + msg.err.Error()
-			m.statusKind = statusError
-			return m, clearStatusAfter(m.statusID, 5*time.Second)
+			return m, m.setStatus("Update failed: "+msg.err.Error(), statusError, 5*time.Second)
 		}
-		m.statusMsg = fmt.Sprintf("Updated to %s — restart lazycron to use the new version", msg.newVersion)
-		m.statusKind = statusSuccess
-		return m, clearStatusAfter(m.statusID, 8*time.Second)
+		return m, m.setStatus(fmt.Sprintf("Updated to %s — restart lazycron to use the new version", msg.newVersion), statusSuccess, 8*time.Second)
 
 	case clearStatusMsg:
 		if msg.id == m.statusID {

--- a/ui/update_dialogs.go
+++ b/ui/update_dialogs.go
@@ -20,10 +20,7 @@ func (m Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.executeConfirmDelete()
 	case "n", "N", "esc":
 		m.mode = modeNormal
-		m.statusMsg = "Cancelled"
-		m.statusKind = statusInfo
-		m.statusID++
-		return m, clearStatusAfter(m.statusID, 3*time.Second)
+		return m, m.setStatus("Cancelled", statusInfo, 3*time.Second)
 	}
 	return m, nil
 }
@@ -31,22 +28,16 @@ func (m Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m Model) executeConfirmDelete() (tea.Model, tea.Cmd) {
 	if !m.confirmYes {
 		m.mode = modeNormal
-		m.statusMsg = "Cancelled"
-		m.statusKind = statusInfo
-		m.statusID++
-		return m, clearStatusAfter(m.statusID, 3*time.Second)
+		return m, m.setStatus("Cancelled", statusInfo, 3*time.Second)
 	}
 	jobIdx := m.currentJobIndex()
 	if jobIdx >= 0 && jobIdx < len(m.jobs) {
 		name := m.jobs[jobIdx].Name
 		m.jobs = append(m.jobs[:jobIdx], m.jobs[jobIdx+1:]...)
 		m.clampSelectedRow()
-		m.statusMsg = fmt.Sprintf("Deleted job '%s'", name)
-		m.statusKind = statusSuccess
 		m.mode = modeNormal
-		m.statusID++
 		b := m.manager.ActiveBackend()
-		return m, tea.Batch(saveJobs(b, m.jobs), clearStatusAfter(m.statusID, 4*time.Second))
+		return m, tea.Batch(saveJobs(b, m.jobs), m.setStatus(fmt.Sprintf("Deleted job '%s'", name), statusSuccess, 4*time.Second))
 	}
 	return m, nil
 }
@@ -71,10 +62,7 @@ func (m Model) handleConfirmDeleteHistoryKey(msg tea.KeyMsg) (tea.Model, tea.Cmd
 		return m.executeConfirmDeleteHistory()
 	case "n", "N", "esc":
 		m.mode = modeNormal
-		m.statusMsg = "Cancelled"
-		m.statusKind = statusInfo
-		m.statusID++
-		return m, clearStatusAfter(m.statusID, 3*time.Second)
+		return m, m.setStatus("Cancelled", statusInfo, 3*time.Second)
 	}
 	return m, nil
 }
@@ -82,10 +70,7 @@ func (m Model) handleConfirmDeleteHistoryKey(msg tea.KeyMsg) (tea.Model, tea.Cmd
 func (m Model) executeConfirmDeleteHistory() (tea.Model, tea.Cmd) {
 	if !m.confirmYes {
 		m.mode = modeNormal
-		m.statusMsg = "Cancelled"
-		m.statusKind = statusInfo
-		m.statusID++
-		return m, clearStatusAfter(m.statusID, 3*time.Second)
+		return m, m.setStatus("Cancelled", statusInfo, 3*time.Second)
 	}
 	if m.historySelected >= 0 && m.historySelected < len(m.history) {
 		entry := m.history[m.historySelected]
@@ -98,11 +83,8 @@ func (m Model) executeConfirmDeleteHistory() (tea.Model, tea.Cmd) {
 		if m.historySelected >= len(m.history) && m.historySelected > 0 {
 			m.historySelected--
 		}
-		m.statusMsg = fmt.Sprintf("Deleted history entry '%s'", entry.JobName)
-		m.statusKind = statusSuccess
 		m.mode = modeNormal
-		m.statusID++
-		cmds = append(cmds, clearStatusAfter(m.statusID, 4*time.Second))
+		cmds = append(cmds, m.setStatus(fmt.Sprintf("Deleted history entry '%s'", entry.JobName), statusSuccess, 4*time.Second))
 		return m, tea.Batch(cmds...)
 	}
 	return m, nil
@@ -116,26 +98,22 @@ func (m Model) handleProjectPromptKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			newProject := strings.TrimSpace(m.projectInput.Value())
 			m.jobs[jobIdx].Project = newProject
 			m.mode = modeNormal
+			var statusText string
 			if newProject != "" {
-				m.statusMsg = fmt.Sprintf("Set project '%s' on '%s'", newProject, m.jobs[jobIdx].Name)
+				statusText = fmt.Sprintf("Set project '%s' on '%s'", newProject, m.jobs[jobIdx].Name)
 			} else {
-				m.statusMsg = fmt.Sprintf("Cleared project on '%s'", m.jobs[jobIdx].Name)
+				statusText = fmt.Sprintf("Cleared project on '%s'", m.jobs[jobIdx].Name)
 			}
-			m.statusKind = statusSuccess
-			m.statusID++
 			// Rebuild rows and move selection to follow the job
 			rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 			m.selectedRow = rowForJobIdx(rows, jobIdx)
 			b := m.manager.ActiveBackend()
-			return m, tea.Batch(saveJobs(b, m.jobs), clearStatusAfter(m.statusID, 4*time.Second))
+			return m, tea.Batch(saveJobs(b, m.jobs), m.setStatus(statusText, statusSuccess, 4*time.Second))
 		}
 		m.mode = modeNormal
 	case "esc":
 		m.mode = modeNormal
-		m.statusMsg = "Cancelled"
-		m.statusKind = statusInfo
-		m.statusID++
-		return m, clearStatusAfter(m.statusID, 3*time.Second)
+		return m, m.setStatus("Cancelled", statusInfo, 3*time.Second)
 	default:
 		var cmd tea.Cmd
 		m.projectInput, cmd = m.projectInput.Update(msg)

--- a/ui/update_form.go
+++ b/ui/update_form.go
@@ -36,10 +36,7 @@ func (m Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "esc":
 			m.mode = modeNormal
-			m.statusMsg = "Cancelled"
-			m.statusKind = statusInfo
-			m.statusID++
-			return m, clearStatusAfter(m.statusID, 3*time.Second)
+			return m, m.setStatus("Cancelled", statusInfo, 3*time.Second)
 		case "tab":
 			cmd := m.form.nextField()
 			return m, cmd
@@ -99,39 +96,32 @@ func (m Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "esc":
 		m.mode = modeNormal
-		m.statusMsg = "Cancelled"
-		m.statusKind = statusInfo
-		m.statusID++
-		return m, clearStatusAfter(m.statusID, 3*time.Second)
+		return m, m.setStatus("Cancelled", statusInfo, 3*time.Second)
 
 	case "enter":
 		job, err := m.form.buildJob()
 		if err != nil {
-			m.statusMsg = err.Error()
-			m.statusKind = statusError
-			m.statusID++
-			return m, clearStatusAfter(m.statusID, 5*time.Second)
+			return m, m.setStatus(err.Error(), statusError, 5*time.Second)
 		}
 
 		b := m.manager.ActiveBackend()
+		var statusText string
 		if m.form.editing {
 			job.Enabled = m.jobs[m.form.editIndex].Enabled
 			m.jobs[m.form.editIndex] = job
 			// Re-position selection to follow the job (project may have changed)
 			rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 			m.selectedRow = rowForJobIdx(rows, m.form.editIndex)
-			m.statusMsg = fmt.Sprintf("Updated job '%s'", job.Name)
+			statusText = fmt.Sprintf("Updated job '%s'", job.Name)
 		} else {
 			m.jobs = append(m.jobs, job)
 			// Point selectedRow to the new job's visual row
 			rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 			m.selectedRow = rowForJobIdx(rows, len(m.jobs)-1)
-			m.statusMsg = fmt.Sprintf("Created job '%s'", job.Name)
+			statusText = fmt.Sprintf("Created job '%s'", job.Name)
 		}
-		m.statusKind = statusSuccess
 		m.mode = modeNormal
-		m.statusID++
-		return m, tea.Batch(saveJobs(b, m.jobs), clearStatusAfter(m.statusID, 4*time.Second))
+		return m, tea.Batch(saveJobs(b, m.jobs), m.setStatus(statusText, statusSuccess, 4*time.Second))
 
 	case "tab":
 		cmd := m.form.nextField()

--- a/ui/update_normal.go
+++ b/ui/update_normal.go
@@ -142,11 +142,8 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					m.jobs[jobIdx], m.jobs[swapIdx] = m.jobs[swapIdx], m.jobs[jobIdx]
 					rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 					m.selectedRow = rowForJobIdx(rows, swapIdx)
-					m.statusMsg = fmt.Sprintf("Moved '%s' up", m.jobs[swapIdx].Name)
-					m.statusKind = statusInfo
-					m.statusID++
 					b := m.manager.ActiveBackend()
-					return m, tea.Batch(saveJobs(b, m.jobs), clearStatusAfter(m.statusID, 2*time.Second))
+					return m, tea.Batch(saveJobs(b, m.jobs), m.setStatus(fmt.Sprintf("Moved '%s' up", m.jobs[swapIdx].Name), statusInfo, 2*time.Second))
 				}
 			}
 		}
@@ -160,11 +157,8 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					m.jobs[jobIdx], m.jobs[swapIdx] = m.jobs[swapIdx], m.jobs[jobIdx]
 					rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
 					m.selectedRow = rowForJobIdx(rows, swapIdx)
-					m.statusMsg = fmt.Sprintf("Moved '%s' down", m.jobs[swapIdx].Name)
-					m.statusKind = statusInfo
-					m.statusID++
 					b := m.manager.ActiveBackend()
-					return m, tea.Batch(saveJobs(b, m.jobs), clearStatusAfter(m.statusID, 2*time.Second))
+					return m, tea.Batch(saveJobs(b, m.jobs), m.setStatus(fmt.Sprintf("Moved '%s' down", m.jobs[swapIdx].Name), statusInfo, 2*time.Second))
 				}
 			}
 		}
@@ -235,18 +229,13 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				}
 				m.manager.SetServerStatus(idx, backend.ConnDisconnected, "")
 				m.manager.InvalidateCache(idx)
-				m.statusMsg = fmt.Sprintf("Disconnected from %s", info.Name)
-				m.statusKind = statusInfo
-				m.statusID++
+				cmd := m.setStatus(fmt.Sprintf("Disconnected from %s", info.Name), statusInfo, 3*time.Second)
 				if m.manager.ActiveIndex() == idx {
 					m.manager.SwitchTo(0)
 					b := m.manager.ActiveBackend()
-					return m, tea.Batch(
-						loadJobs(b), loadHistory(b),
-						clearStatusAfter(m.statusID, 3*time.Second),
-					)
+					return m, tea.Batch(loadJobs(b), loadHistory(b), cmd)
 				}
-				return m, clearStatusAfter(m.statusID, 3*time.Second)
+				return m, cmd
 			}
 		}
 
@@ -290,11 +279,8 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				if !m.jobs[jobIdx].Enabled {
 					status = "disabled"
 				}
-				m.statusMsg = fmt.Sprintf("Job '%s' %s", m.jobs[jobIdx].Name, status)
-				m.statusKind = statusSuccess
-				m.statusID++
 				b := m.manager.ActiveBackend()
-				return m, tea.Batch(saveJobs(b, m.jobs), clearStatusAfter(m.statusID, 4*time.Second))
+				return m, tea.Batch(saveJobs(b, m.jobs), m.setStatus(fmt.Sprintf("Job '%s' %s", m.jobs[jobIdx].Name, status), statusSuccess, 4*time.Second))
 			}
 		}
 
@@ -328,17 +314,11 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if jobIdx >= 0 {
 				job := &m.jobs[jobIdx]
 				if job.Wrapped {
-					m.statusMsg = fmt.Sprintf("Job '%s' is already up to date", job.Name)
-					m.statusKind = statusInfo
-					m.statusID++
-					return m, clearStatusAfter(m.statusID, 3*time.Second)
+					return m, m.setStatus(fmt.Sprintf("Job '%s' is already up to date", job.Name), statusInfo, 3*time.Second)
 				}
 				job.Wrapped = true
-				m.statusMsg = fmt.Sprintf("Updated '%s' to latest format", job.Name)
-				m.statusKind = statusSuccess
-				m.statusID++
 				b := m.manager.ActiveBackend()
-				return m, tea.Batch(saveJobs(b, m.jobs), clearStatusAfter(m.statusID, 4*time.Second))
+				return m, tea.Batch(saveJobs(b, m.jobs), m.setStatus(fmt.Sprintf("Updated '%s' to latest format", job.Name), statusSuccess, 4*time.Second))
 			}
 		}
 
@@ -383,10 +363,7 @@ func (m Model) switchToServer(index int) (tea.Model, tea.Cmd) {
 	if index == 0 {
 		m.manager.SwitchTo(0)
 		b := m.manager.ActiveBackend()
-		m.statusMsg = "Switched to local"
-		m.statusKind = statusSuccess
-		m.statusID++
-		return m, tea.Batch(loadJobs(b), loadHistory(b), clearStatusAfter(m.statusID, 3*time.Second))
+		return m, tea.Batch(loadJobs(b), loadHistory(b), m.setStatus("Switched to local", statusSuccess, 3*time.Second))
 	}
 
 	if info.Status == backend.ConnConnected {

--- a/ui/update_server.go
+++ b/ui/update_server.go
@@ -15,26 +15,17 @@ func (m Model) handleAddServerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch key {
 	case "esc":
 		m.mode = modeNormal
-		m.statusMsg = "Cancelled"
-		m.statusKind = statusInfo
-		m.statusID++
-		return m, clearStatusAfter(m.statusID, 3*time.Second)
+		return m, m.setStatus("Cancelled", statusInfo, 3*time.Second)
 
 	case "enter":
 		srv, err := m.serverForm.buildServerConfig()
 		if err != nil {
-			m.statusMsg = err.Error()
-			m.statusKind = statusError
-			m.statusID++
-			return m, clearStatusAfter(m.statusID, 5*time.Second)
+			return m, m.setStatus(err.Error(), statusError, 5*time.Second)
 		}
 
 		// Save to config file
 		if err := config.AddServer(srv); err != nil {
-			m.statusMsg = "Failed to save config: " + err.Error()
-			m.statusKind = statusError
-			m.statusID++
-			return m, clearStatusAfter(m.statusID, 5*time.Second)
+			return m, m.setStatus("Failed to save config: "+err.Error(), statusError, 5*time.Second)
 		}
 
 		// Add to manager
@@ -50,11 +41,8 @@ func (m Model) handleAddServerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.manager.AddServer(info, remote)
 
 		m.mode = modeNormal
-		m.statusMsg = fmt.Sprintf("Added server '%s'", srv.Name)
-		m.statusKind = statusSuccess
-		m.statusID++
 		m.serverSelected = m.manager.ServerCount() - 1
-		return m, clearStatusAfter(m.statusID, 4*time.Second)
+		return m, m.setStatus(fmt.Sprintf("Added server '%s'", srv.Name), statusSuccess, 4*time.Second)
 
 	case "tab":
 		cmd := m.serverForm.nextField()
@@ -72,18 +60,12 @@ func (m Model) handlePasswordPromptKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
 		m.mode = modeNormal
-		m.statusMsg = "Cancelled"
-		m.statusKind = statusInfo
-		m.statusID++
-		return m, clearStatusAfter(m.statusID, 3*time.Second)
+		return m, m.setStatus("Cancelled", statusInfo, 3*time.Second)
 
 	case "enter":
 		password := m.passwordInput.Value()
 		if password == "" {
-			m.statusMsg = "Password cannot be empty"
-			m.statusKind = statusError
-			m.statusID++
-			return m, clearStatusAfter(m.statusID, 3*time.Second)
+			return m, m.setStatus("Password cannot be empty", statusError, 3*time.Second)
 		}
 		m.mode = modeNormal
 		m.serverSwitching = true
@@ -110,10 +92,7 @@ func (m Model) handleConfirmDeleteServerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 		return m.executeConfirmDeleteServer()
 	case "n", "N", "esc":
 		m.mode = modeNormal
-		m.statusMsg = "Cancelled"
-		m.statusKind = statusInfo
-		m.statusID++
-		return m, clearStatusAfter(m.statusID, 3*time.Second)
+		return m, m.setStatus("Cancelled", statusInfo, 3*time.Second)
 	}
 	return m, nil
 }
@@ -121,10 +100,7 @@ func (m Model) handleConfirmDeleteServerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 func (m Model) executeConfirmDeleteServer() (tea.Model, tea.Cmd) {
 	if !m.confirmYes {
 		m.mode = modeNormal
-		m.statusMsg = "Cancelled"
-		m.statusKind = statusInfo
-		m.statusID++
-		return m, clearStatusAfter(m.statusID, 3*time.Second)
+		return m, m.setStatus("Cancelled", statusInfo, 3*time.Second)
 	}
 	idx := m.serverSelected
 	if idx <= 0 || idx >= m.manager.ServerCount() {
@@ -146,13 +122,10 @@ func (m Model) executeConfirmDeleteServer() (tea.Model, tea.Cmd) {
 	}
 
 	m.mode = modeNormal
-	m.statusMsg = fmt.Sprintf("Removed server '%s'", serverName)
-	m.statusKind = statusSuccess
-	m.statusID++
-
+	cmd := m.setStatus(fmt.Sprintf("Removed server '%s'", serverName), statusSuccess, 4*time.Second)
 	if switchedToLocal {
 		b := m.manager.ActiveBackend()
-		return m, tea.Batch(loadJobs(b), loadHistory(b), clearStatusAfter(m.statusID, 4*time.Second))
+		return m, tea.Batch(loadJobs(b), loadHistory(b), cmd)
 	}
-	return m, clearStatusAfter(m.statusID, 4*time.Second)
+	return m, cmd
 }


### PR DESCRIPTION
Closes #20

## What
- Added a `setStatus(msg, kind, duration)` helper method on `*Model` in `ui/model.go`
- Replaced 30+ instances of the 3–4 line status update boilerplate across 5 files (`update.go`, `update_normal.go`, `update_server.go`, `update_form.go`, `update_dialogs.go`)
- Net reduction of 110 lines (63 added, 173 removed)

## Why
- **DRY**: The `statusMsg`/`statusKind`/`statusID++`/`clearStatusAfter` pattern was repeated 30+ times, violating the DRY principle
- **Readability**: Each handler is now significantly shorter — the intent ("show a success message for 4s") is a single expression instead of a multi-line ritual
- **Correctness**: The ID-increment-then-pass-to-timer sequence is easy to get wrong (e.g., forgetting to increment). The helper makes this impossible to misuse
- **Maintainability**: If the status mechanism ever changes, there's one place to update instead of 30+