### PR TITLE
fix: secure DeleteHistory against path traversal attacks (fixes #45)

### DIFF
--- a/backend/file_backend.go
+++ b/backend/file_backend.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/swalha1999/lazycron/cron"
@@ -65,10 +66,30 @@ func (b *FileBackend) WriteHistory(jobID, jobName, output string, success bool) 
 
 func (b *FileBackend) DeleteHistory(filePath string) error {
 	// Safety: only delete files within our history directory.
-	if !strings.HasPrefix(filePath, b.historyDir) {
+	// Clean and resolve both paths to absolute form to prevent path traversal.
+	absHistoryDir, err := filepath.Abs(filepath.Clean(b.historyDir))
+	if err != nil {
+		return fmt.Errorf("failed to resolve history dir: %w", err)
+	}
+
+	absFilePath, err := filepath.Abs(filepath.Clean(filePath))
+	if err != nil {
+		return fmt.Errorf("failed to resolve file path: %w", err)
+	}
+
+	// Use filepath.Rel to check if the file is within the history directory.
+	// If Rel returns a path that starts with "..", the file is outside.
+	rel, err := filepath.Rel(absHistoryDir, absFilePath)
+	if err != nil {
 		return fmt.Errorf("refusing to delete file outside history dir")
 	}
-	return os.Remove(filePath)
+
+	// Check if the relative path escapes the directory (contains ..)
+	if strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return fmt.Errorf("refusing to delete file outside history dir")
+	}
+
+	return os.Remove(absFilePath)
 }
 
 func (b *FileBackend) EnsureRecordScript() error { return nil }

--- a/backend/file_backend_test.go
+++ b/backend/file_backend_test.go
@@ -87,10 +87,56 @@ func TestFileBackend_DeleteHistoryOutsideDir(t *testing.T) {
 
 	fb := NewFileBackend(cronFile, histDir)
 
-	// Attempting to delete a file outside the history dir should fail.
+	// Test 1: Absolute path outside the history dir should fail.
 	err := fb.DeleteHistory("/tmp/some-other-file")
 	if err == nil {
 		t.Fatal("expected error deleting file outside history dir")
+	}
+
+	// Test 2: Path traversal with ../ should fail.
+	err = fb.DeleteHistory(filepath.Join(histDir, "..", "other-dir", "file.txt"))
+	if err == nil {
+		t.Fatal("expected error for path traversal with ../")
+	}
+
+	// Test 3: Similar directory name should fail (e.g., /tmp/history vs /tmp/history-other).
+	similarDir := histDir + "-other"
+	err = fb.DeleteHistory(filepath.Join(similarDir, "file.txt"))
+	if err == nil {
+		t.Fatal("expected error for similar directory name")
+	}
+
+	// Test 4: Absolute path with traversal should fail.
+	err = fb.DeleteHistory(histDir + "/../sensitive/file.txt")
+	if err == nil {
+		t.Fatal("expected error for absolute path with traversal")
+	}
+
+	// Test 5: Path starting with history dir but escaping should fail.
+	// Create a temp file outside the history dir for this test.
+	outsideFile := filepath.Join(dir, "outside.txt")
+	if err := os.WriteFile(outsideFile, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err = fb.DeleteHistory(outsideFile)
+	if err == nil {
+		t.Fatal("expected error for file outside history dir")
+	}
+
+	// Test 6: Valid path within history dir should succeed.
+	if err := os.MkdirAll(histDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	validFile := filepath.Join(histDir, "valid.txt")
+	if err := os.WriteFile(validFile, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err = fb.DeleteHistory(validFile)
+	if err != nil {
+		t.Fatalf("expected no error for valid file in history dir, got: %v", err)
+	}
+	if _, err := os.Stat(validFile); !os.IsNotExist(err) {
+		t.Fatal("expected file to be deleted")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixed path traversal vulnerability in `FileBackend.DeleteHistory` 
- Replaced insecure `strings.HasPrefix` check with proper path validation
- Added comprehensive security tests

## Changes
- Use `filepath.Clean()` and `filepath.Abs()` to normalize paths
- Use `filepath.Rel()` to securely verify the file is within the history directory
- Prevent attacks including:
  - Path traversal with `../` sequences
  - Similar directory name bypasses (e.g., `/tmp/history` vs `/tmp/history-other`)
  - Absolute path attacks

## Test Plan
- [x] All existing tests pass
- [x] Added 6 new security test cases covering various attack vectors
- [x] Verified valid files can still be deleted
- [x] Verified malicious paths are properly rejected

Fixes #45