### PR TITLE
Feat #15: Show last-run health indicator on each job in the Jobs panel

### DIFF
--- a/ui/joblist.go
+++ b/ui/joblist.go
@@ -128,7 +128,7 @@ func findSiblingJob(jobs []cron.Job, jobIdx int, direction int) int {
 	return siblings[targetPos]
 }
 
-func renderJobList(jobs []cron.Job, selRow int, rows []listRow, width, height int, collapsed map[string]bool) string {
+func renderJobList(jobs []cron.Job, selRow int, rows []listRow, width, height int, collapsed map[string]bool, lastRunStatus map[string]*bool) string {
 	if len(jobs) == 0 {
 		empty := mutedItemStyle.Render("No cron jobs found")
 		hint := mutedItemStyle.Render("Press 'n' to create one")
@@ -177,7 +177,7 @@ func renderJobList(jobs []cron.Job, selRow int, rows []listRow, width, height in
 			b.WriteString(line)
 		} else {
 			job := jobs[row.jobIdx]
-			line := renderJobRow(job, maxNameWidth)
+			line := renderJobRow(job, maxNameWidth, lastRunStatus)
 			if i == selRow {
 				line = selectedStyle.Render("▶ " + line)
 			} else {
@@ -223,7 +223,7 @@ func renderGroupHeader(project string, jobs []cron.Job, collapsed map[string]boo
 	return lipgloss.NewStyle().Foreground(colorMauve).Bold(true).Render(header)
 }
 
-func renderJobRow(job cron.Job, maxNameWidth int) string {
+func renderJobRow(job cron.Job, maxNameWidth int, lastRunStatus map[string]*bool) string {
 	// Status dot
 	dot := enabledDotStyle.Render("●")
 	if !job.Enabled {
@@ -236,8 +236,18 @@ func renderJobRow(job cron.Job, maxNameWidth int) string {
 		name = name[:maxNameWidth-1] + "…"
 	}
 
+	// Last-run health indicator
+	healthIndicator := ""
+	if s, ok := lastRunStatus[job.Name]; ok && s != nil {
+		if *s {
+			healthIndicator = " " + lipgloss.NewStyle().Foreground(colorGreen).Render("✓")
+		} else {
+			healthIndicator = " " + lipgloss.NewStyle().Foreground(colorRed).Bold(true).Render("✗")
+		}
+	}
+
 	// Build inline badges right after the name
-	nameWithBadges := name
+	nameWithBadges := name + healthIndicator
 	if job.Tag != "" {
 		tagColor := job.TagColor
 		if tagColor == "" {

--- a/ui/model.go
+++ b/ui/model.go
@@ -94,6 +94,9 @@ type Model struct {
 	selectedRow       int             // visual row index in grouped job list
 	projectInput      textinput.Model // for quick-assign project prompt
 
+	// Last-run health indicator: jobName → success (nil means no history)
+	lastRunStatus map[string]*bool
+
 	// Search/filter state
 	searchInput textinput.Model
 	searchQuery string       // active filter text
@@ -146,6 +149,18 @@ func NewModel(mgr *backend.Manager, version string) Model {
 		searchPanel:       -1,
 		version:           version,
 	}
+}
+
+// buildLastRunStatus builds a map from job name to most recent run success status.
+// History entries are sorted by timestamp descending, so the first match per job wins.
+func buildLastRunStatus(entries []history.Entry) map[string]*bool {
+	status := make(map[string]*bool, len(entries))
+	for i := range entries {
+		if _, exists := status[entries[i].JobName]; !exists {
+			status[entries[i].JobName] = entries[i].Success
+		}
+	}
+	return status
 }
 
 // activeDirLister returns a DirLister for the active backend.

--- a/ui/model_test.go
+++ b/ui/model_test.go
@@ -1,0 +1,55 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/swalha1999/lazycron/history"
+)
+
+func boolPtr(v bool) *bool { return &v }
+
+func TestBuildLastRunStatus(t *testing.T) {
+	// History is sorted by timestamp descending (most recent first).
+	entries := []history.Entry{
+		{JobName: "backup", Success: boolPtr(true), Timestamp: "2026-03-24T10:00:00Z"},
+		{JobName: "sync", Success: boolPtr(false), Timestamp: "2026-03-24T09:00:00Z"},
+		{JobName: "backup", Success: boolPtr(false), Timestamp: "2026-03-24T08:00:00Z"}, // older, should be ignored
+	}
+
+	status := buildLastRunStatus(entries)
+
+	// "backup" should reflect the most recent (first) entry: true
+	if s, ok := status["backup"]; !ok || s == nil || *s != true {
+		t.Errorf("backup: got %v, want true", status["backup"])
+	}
+
+	// "sync" should be false
+	if s, ok := status["sync"]; !ok || s == nil || *s != false {
+		t.Errorf("sync: got %v, want false", status["sync"])
+	}
+
+	// "unknown" should not be present
+	if _, ok := status["unknown"]; ok {
+		t.Error("unknown job should not be in status map")
+	}
+}
+
+func TestBuildLastRunStatus_Empty(t *testing.T) {
+	status := buildLastRunStatus(nil)
+	if len(status) != 0 {
+		t.Errorf("expected empty map, got %d entries", len(status))
+	}
+}
+
+func TestBuildLastRunStatus_NilSuccess(t *testing.T) {
+	entries := []history.Entry{
+		{JobName: "legacy", Success: nil, Timestamp: "2026-03-24T10:00:00Z"},
+	}
+
+	status := buildLastRunStatus(entries)
+	if s, ok := status["legacy"]; !ok {
+		t.Error("legacy should be in map")
+	} else if s != nil {
+		t.Errorf("legacy: got %v, want nil", *s)
+	}
+}

--- a/ui/update.go
+++ b/ui/update.go
@@ -52,6 +52,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case historyLoadedMsg:
 		if msg.err == nil {
 			m.history = msg.entries
+			m.lastRunStatus = buildLastRunStatus(m.history)
 			// Auto-disable completed one-shot jobs (backup for record.sh)
 			if len(m.jobs) > 0 && len(m.history) > 0 {
 				return m, disableCompletedOneShots(m.manager.ActiveBackend(), m.jobs, m.history)
@@ -145,6 +146,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.index == m.manager.ActiveIndex() {
 			m.jobs = msg.jobs
 			m.history = msg.history
+			m.lastRunStatus = buildLastRunStatus(m.history)
 			m.selected = 0
 			m.selectedRow = 0
 			m.historySelected = 0

--- a/ui/view.go
+++ b/ui/view.go
@@ -171,7 +171,7 @@ func (m Model) renderPanels(height int) string {
 
 	// [2] Jobs panel
 	rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
-	listContent := renderJobList(m.jobs, m.selectedRow, rows, listWidth-4, jobsHeight, m.collapsedProjects)
+	listContent := renderJobList(m.jobs, m.selectedRow, rows, listWidth-4, jobsHeight, m.collapsedProjects, m.lastRunStatus)
 	jobsActive := m.focusPanel == panelJobs
 	jobsPanelStyle := panelStyle
 	if jobsActive {


### PR DESCRIPTION
Closes #15

## Summary
- Adds a **✓** (green) or **✗** (red) health indicator next to each job name in the Jobs panel, based on the most recent history entry
- Jobs with no history show no indicator
- The indicator updates automatically on history refresh (tick, manual run with `r`, server switch)

## Implementation
- Added `lastRunStatus map[string]*bool` field to the UI Model, rebuilt whenever history is loaded
- `buildLastRunStatus()` iterates history entries (already sorted by timestamp desc) and takes the first match per job name — O(n) with no extra sorting
- `renderJobRow()` renders the indicator right after the job name, before tags/badges, visually distinct from the enabled/disabled dot
- Added unit tests for `buildLastRunStatus` covering normal, empty, and nil-success cases

## Test plan
- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [x] New unit tests for `buildLastRunStatus` (3 test cases)