### PR TITLE
Feat #15: Show last-run health indicator on each job in Jobs panel

### DIFF
--- a/ui/joblist.go
+++ b/ui/joblist.go
@@ -128,7 +128,7 @@ func findSiblingJob(jobs []cron.Job, jobIdx int, direction int) int {
 	return siblings[targetPos]
 }
 
-func renderJobList(jobs []cron.Job, selRow int, rows []listRow, width, height int, collapsed map[string]bool) string {
+func renderJobList(jobs []cron.Job, selRow int, rows []listRow, width, height int, collapsed map[string]bool, lastRunStatus map[string]*bool) string {
 	if len(jobs) == 0 {
 		empty := mutedItemStyle.Render("No cron jobs found")
 		hint := mutedItemStyle.Render("Press 'n' to create one")
@@ -177,7 +177,7 @@ func renderJobList(jobs []cron.Job, selRow int, rows []listRow, width, height in
 			b.WriteString(line)
 		} else {
 			job := jobs[row.jobIdx]
-			line := renderJobRow(job, maxNameWidth)
+			line := renderJobRow(job, maxNameWidth, lastRunStatus)
 			if i == selRow {
 				line = selectedStyle.Render("▶ " + line)
 			} else {
@@ -223,7 +223,7 @@ func renderGroupHeader(project string, jobs []cron.Job, collapsed map[string]boo
 	return lipgloss.NewStyle().Foreground(colorMauve).Bold(true).Render(header)
 }
 
-func renderJobRow(job cron.Job, maxNameWidth int) string {
+func renderJobRow(job cron.Job, maxNameWidth int, lastRunStatus map[string]*bool) string {
 	// Status dot
 	dot := enabledDotStyle.Render("●")
 	if !job.Enabled {
@@ -236,8 +236,18 @@ func renderJobRow(job cron.Job, maxNameWidth int) string {
 		name = name[:maxNameWidth-1] + "…"
 	}
 
+	// Last-run health indicator
+	healthIndicator := ""
+	if status, ok := lastRunStatus[job.ID]; ok && status != nil {
+		if *status {
+			healthIndicator = " " + lipgloss.NewStyle().Foreground(colorGreen).Render("✓")
+		} else {
+			healthIndicator = " " + lipgloss.NewStyle().Foreground(colorRed).Bold(true).Render("✗")
+		}
+	}
+
 	// Build inline badges right after the name
-	nameWithBadges := name
+	nameWithBadges := name + healthIndicator
 	if job.Tag != "" {
 		tagColor := job.TagColor
 		if tagColor == "" {

--- a/ui/joblist_test.go
+++ b/ui/joblist_test.go
@@ -1,0 +1,104 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/swalha1999/lazycron/history"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestBuildLastRunStatus(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []history.Entry
+		wantLen int
+		checks  map[string]*bool // job ID → expected success value
+	}{
+		{
+			name:    "empty history",
+			entries: nil,
+			wantLen: 0,
+		},
+		{
+			name: "single successful entry",
+			entries: []history.Entry{
+				{JobID: "abc123", Success: boolPtr(true), Timestamp: "2026-03-25T10:00:00Z"},
+			},
+			wantLen: 1,
+			checks:  map[string]*bool{"abc123": boolPtr(true)},
+		},
+		{
+			name: "single failed entry",
+			entries: []history.Entry{
+				{JobID: "abc123", Success: boolPtr(false), Timestamp: "2026-03-25T10:00:00Z"},
+			},
+			wantLen: 1,
+			checks:  map[string]*bool{"abc123": boolPtr(false)},
+		},
+		{
+			name: "most recent entry wins (already sorted newest first)",
+			entries: []history.Entry{
+				{JobID: "abc123", Success: boolPtr(true), Timestamp: "2026-03-25T12:00:00Z"},
+				{JobID: "abc123", Success: boolPtr(false), Timestamp: "2026-03-25T10:00:00Z"},
+			},
+			wantLen: 1,
+			checks:  map[string]*bool{"abc123": boolPtr(true)},
+		},
+		{
+			name: "multiple jobs",
+			entries: []history.Entry{
+				{JobID: "job1", Success: boolPtr(true), Timestamp: "2026-03-25T12:00:00Z"},
+				{JobID: "job2", Success: boolPtr(false), Timestamp: "2026-03-25T11:00:00Z"},
+				{JobID: "job1", Success: boolPtr(false), Timestamp: "2026-03-25T10:00:00Z"},
+			},
+			wantLen: 2,
+			checks: map[string]*bool{
+				"job1": boolPtr(true),
+				"job2": boolPtr(false),
+			},
+		},
+		{
+			name: "entries with empty job ID are skipped",
+			entries: []history.Entry{
+				{JobID: "", Success: boolPtr(true), Timestamp: "2026-03-25T12:00:00Z"},
+				{JobID: "abc123", Success: boolPtr(false), Timestamp: "2026-03-25T10:00:00Z"},
+			},
+			wantLen: 1,
+			checks:  map[string]*bool{"abc123": boolPtr(false)},
+		},
+		{
+			name: "nil success pointer preserved",
+			entries: []history.Entry{
+				{JobID: "abc123", Success: nil, Timestamp: "2026-03-25T10:00:00Z"},
+			},
+			wantLen: 1,
+			checks:  map[string]*bool{"abc123": nil},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildLastRunStatus(tt.entries)
+			if len(result) != tt.wantLen {
+				t.Errorf("got len %d, want %d", len(result), tt.wantLen)
+			}
+			for id, wantSuccess := range tt.checks {
+				gotSuccess, ok := result[id]
+				if !ok {
+					t.Errorf("missing key %q", id)
+					continue
+				}
+				if wantSuccess == nil {
+					if gotSuccess != nil {
+						t.Errorf("key %q: got %v, want nil", id, *gotSuccess)
+					}
+				} else if gotSuccess == nil {
+					t.Errorf("key %q: got nil, want %v", id, *wantSuccess)
+				} else if *gotSuccess != *wantSuccess {
+					t.Errorf("key %q: got %v, want %v", id, *gotSuccess, *wantSuccess)
+				}
+			}
+		})
+	}
+}

--- a/ui/model.go
+++ b/ui/model.go
@@ -100,6 +100,9 @@ type Model struct {
 	searchPanel int          // panel the filter applies to (-1 = none)
 	searchJobMatch map[int]bool // set of matching job indices (nil = all)
 
+	// Last-run status indicator per job (maps job ID → success of most recent run)
+	lastRunStatus map[string]*bool
+
 	// App version (for self-update)
 	version string
 }
@@ -146,6 +149,23 @@ func NewModel(mgr *backend.Manager, version string) Model {
 		searchPanel:       -1,
 		version:           version,
 	}
+}
+
+// buildLastRunStatus builds a map from job ID to the success status of the
+// most recent history entry. History entries are already sorted newest-first,
+// so the first occurrence of each job ID is its latest run.
+func buildLastRunStatus(entries []history.Entry) map[string]*bool {
+	m := make(map[string]*bool, len(entries))
+	for _, e := range entries {
+		key := e.JobID
+		if key == "" {
+			continue
+		}
+		if _, exists := m[key]; !exists {
+			m[key] = e.Success
+		}
+	}
+	return m
 }
 
 // activeDirLister returns a DirLister for the active backend.

--- a/ui/update.go
+++ b/ui/update.go
@@ -52,6 +52,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case historyLoadedMsg:
 		if msg.err == nil {
 			m.history = msg.entries
+			m.lastRunStatus = buildLastRunStatus(m.history)
 			// Auto-disable completed one-shot jobs (backup for record.sh)
 			if len(m.jobs) > 0 && len(m.history) > 0 {
 				return m, disableCompletedOneShots(m.manager.ActiveBackend(), m.jobs, m.history)
@@ -145,6 +146,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.index == m.manager.ActiveIndex() {
 			m.jobs = msg.jobs
 			m.history = msg.history
+			m.lastRunStatus = buildLastRunStatus(m.history)
 			m.selected = 0
 			m.selectedRow = 0
 			m.historySelected = 0

--- a/ui/view.go
+++ b/ui/view.go
@@ -171,7 +171,7 @@ func (m Model) renderPanels(height int) string {
 
 	// [2] Jobs panel
 	rows := buildRows(m.jobs, m.collapsedProjects, m.searchJobMatch)
-	listContent := renderJobList(m.jobs, m.selectedRow, rows, listWidth-4, jobsHeight, m.collapsedProjects)
+	listContent := renderJobList(m.jobs, m.selectedRow, rows, listWidth-4, jobsHeight, m.collapsedProjects, m.lastRunStatus)
 	jobsActive := m.focusPanel == panelJobs
 	jobsPanelStyle := panelStyle
 	if jobsActive {


### PR DESCRIPTION
Closes #15

## Summary
- Adds a **✓** (green) / **✗** (red) last-run health indicator next to each job name in the Jobs panel, based on the most recent history entry
- Jobs with no history show no indicator
- The `lastRunStatus` map (`map[jobID]*bool`) is rebuilt on every history load — after periodic ticks, manual runs, and server switches — so it always reflects current state
- Uses first-occurrence-wins over the already-sorted (newest-first) history entries for O(n) construction

## Files changed
- **`ui/model.go`** — Added `lastRunStatus` field and `buildLastRunStatus()` helper
- **`ui/update.go`** — Rebuild status map on `historyLoadedMsg` and `serverDataLoadedMsg`
- **`ui/joblist.go`** — Render ✓/✗ indicator in `renderJobRow()`; updated signatures
- **`ui/view.go`** — Pass `lastRunStatus` to `renderJobList()`
- **`ui/joblist_test.go`** — Table-driven tests for `buildLastRunStatus()`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (including new `TestBuildLastRunStatus`)
- [x] E2E tests pass