### PR TITLE
Feat #16: Duplicate/clone job with a single keypress

### DIFF
--- a/ui/bars.go
+++ b/ui/bars.go
@@ -54,6 +54,7 @@ func renderBottomBar(m mode, focusPanel int, statusMsg string, statusKind status
 				helpBinding("D", "remove") + helpSep()
 		} else if focusPanel == panelJobs {
 			help = helpBinding("n", "new") + helpSep() +
+				helpBinding("d", "duplicate") + helpSep() +
 				helpBinding("enter", "edit") + helpSep() +
 				helpBinding("space", "toggle") + helpSep() +
 				helpBinding("r", "run") + helpSep() +
@@ -135,6 +136,7 @@ func renderHelpScreen() string {
 		{"D", "Remove server"},
 		{"", "── Jobs Panel ──"},
 		{"n", "Create new job"},
+		{"d", "Duplicate selected job"},
 		{"enter / e", "Edit selected job"},
 		{"D", "Delete selected job"},
 		{"space", "Toggle enable/disable"},

--- a/ui/form.go
+++ b/ui/form.go
@@ -70,6 +70,41 @@ func newForm(lister DirLister) formModel {
 	return f
 }
 
+func newFormForDuplicate(job cron.Job, lister DirLister) formModel {
+	f := formModel{}
+	for i := 0; i < fieldCount; i++ {
+		f.inputs[i] = newInput(i)
+	}
+	f.completer.lister = lister
+
+	// Extract workdir from command
+	cmd := job.Command
+	workDir := ""
+	if strings.HasPrefix(cmd, "cd ") {
+		if idx := strings.Index(cmd, " && "); idx != -1 {
+			workDir = strings.TrimPrefix(cmd[:idx], "cd ")
+			cmd = strings.TrimSpace(cmd[idx+4:])
+		}
+	}
+
+	// No ID — a new one will be generated on save
+	f.inputs[fieldName].SetValue(job.Name + " (copy)")
+	f.inputs[fieldCommand].SetValue(cmd)
+	f.inputs[fieldSchedule].SetValue(job.Schedule)
+	f.inputs[fieldWorkDir].SetValue(workDir)
+	f.inputs[fieldProject].SetValue(job.Project)
+	f.tag = job.Tag
+	f.tagColor = job.TagColor
+	f.oneShot = job.OneShot
+
+	f.picker = newPicker()
+	if !f.oneShot {
+		f.picker.ParseExpression(job.Schedule)
+	}
+
+	return f
+}
+
 func newFormForEdit(job cron.Job, index int, lister DirLister) formModel {
 	f := formModel{
 		editing:   true,

--- a/ui/update_normal.go
+++ b/ui/update_normal.go
@@ -216,6 +216,15 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case "d":
+		if m.focusPanel == panelJobs && len(m.jobs) > 0 && !m.isOnHeader() {
+			jobIdx := m.currentJobIndex()
+			if jobIdx >= 0 {
+				m.mode = modeForm
+				m.form = newFormForDuplicate(m.jobs[jobIdx], m.activeDirLister())
+				m.statusMsg = ""
+				return m, m.form.focusActive()
+			}
+		}
 		if m.focusPanel == panelServers {
 			idx := m.serverSelected
 			if idx == 0 {


### PR DESCRIPTION
Closes #16

## Summary
- Press `d` on a selected job in the Jobs panel to duplicate it
- Opens the new job form pre-filled with all fields from the source job: name (with " (copy)" suffix), command, schedule, working directory, project, tag, tag color, and one-shot setting
- User can edit any field before saving — a new job ID is generated on save
- Works for both local and remote server contexts
- Keybinding is visible in the bottom help bar and the `?` help screen

## Changes
- **ui/form.go**: Added `newFormForDuplicate()` — creates a new (non-edit) form pre-filled from an existing job
- **ui/update_normal.go**: Added `d` key handler for Jobs panel that opens the duplicate form
- **ui/bars.go**: Added `d duplicate` to bottom bar and help screen