### PR TITLE
Refactor #23: Extract duplicated completer key-handling into shared method

### DIFF
--- a/ui/completer.go
+++ b/ui/completer.go
@@ -41,13 +41,7 @@ type completerModel struct {
 
 // activate initializes the completer for a given input value.
 func (c *completerModel) activate(input string) {
-	input = strings.TrimSpace(input)
-	if input == "" {
-		c.showSeeds()
-		return
-	}
-	c.parseInput(input)
-	c.refresh()
+	c.update(input)
 }
 
 // update refreshes suggestions as the user types.
@@ -59,6 +53,35 @@ func (c *completerModel) update(input string) {
 	}
 	c.parseInput(input)
 	c.refresh()
+}
+
+// handleKey processes completer navigation keys.
+// setInput is called with the selected path when the user drills in/out.
+// Returns true if the key was handled by the completer.
+func (c *completerModel) handleKey(key string, setInput func(string)) bool {
+	switch key {
+	case "down":
+		c.selectNext()
+	case "up":
+		c.selectPrev()
+	case "enter", "right":
+		if c.selected >= 0 {
+			if path := c.drillIn(); path != "" {
+				setInput(path)
+			}
+		} else if key == "right" {
+			// right with no selection: handled (consume the key)
+		} else {
+			return false // enter with no selection: let caller handle
+		}
+	case "left":
+		setInput(c.drillOut())
+	case "esc":
+		c.reset()
+	default:
+		return false
+	}
+	return true
 }
 
 // parseInput splits input into browseDir and filterText.

--- a/ui/update_form.go
+++ b/ui/update_form.go
@@ -52,32 +52,11 @@ func (m Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.form.activeField == fieldWorkDir && m.form.completer.active {
-		switch key {
-		case "down":
-			m.form.completer.selectNext()
-			return m, nil
-		case "up":
-			m.form.completer.selectPrev()
-			return m, nil
-		case "enter", "right":
-			if m.form.completer.selected >= 0 {
-				path := m.form.completer.drillIn()
-				if path != "" {
-					m.form.inputs[fieldWorkDir].SetValue(path)
-					m.form.inputs[fieldWorkDir].CursorEnd()
-				}
-				return m, nil
-			}
-			if key == "right" {
-				return m, nil
-			}
-		case "left":
-			path := m.form.completer.drillOut()
+		handled := m.form.completer.handleKey(key, func(path string) {
 			m.form.inputs[fieldWorkDir].SetValue(path)
 			m.form.inputs[fieldWorkDir].CursorEnd()
-			return m, nil
-		case "esc":
-			m.form.completer.reset()
+		})
+		if handled {
 			return m, nil
 		}
 	}
@@ -203,33 +182,11 @@ func (m Model) handleTemplatePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case phaseVariables:
 		// Handle completer interactions when active on a path variable
 		if tp.activeVarIsPath() && tp.completer.active {
-			switch key {
-			case "down":
-				tp.completer.selectNext()
-				return m, nil
-			case "up":
-				tp.completer.selectPrev()
-				return m, nil
-			case "enter", "right":
-				if tp.completer.selected >= 0 {
-					path := tp.completer.drillIn()
-					if path != "" {
-						tp.variableInputs[tp.activeVariable].SetValue(path)
-						tp.variableInputs[tp.activeVariable].CursorEnd()
-					}
-					return m, nil
-				}
-				if key == "right" {
-					return m, nil
-				}
-				// enter with no selection falls through to create job
-			case "left":
-				path := tp.completer.drillOut()
+			handled := tp.completer.handleKey(key, func(path string) {
 				tp.variableInputs[tp.activeVariable].SetValue(path)
 				tp.variableInputs[tp.activeVariable].CursorEnd()
-				return m, nil
-			case "esc":
-				tp.completer.reset()
+			})
+			if handled {
 				return m, nil
 			}
 		}


### PR DESCRIPTION
Closes #23

## What
- Added `completerModel.handleKey(key string, setInput func(string)) bool` method in `completer.go` that encapsulates the navigation key dispatch logic (up/down/enter/right/left/esc) with a callback for setting the input value
- Replaced ~30 lines of duplicated switch/case logic in both `handleFormKey` and `handleTemplatePickerKey` (in `update_form.go`) with calls to the new shared method
- Made `completerModel.activate()` delegate to `update()` since their implementations were identical

## Why
- Eliminates bug risk from the two copies drifting out of sync (a fix applied to one but not the other)
- Improves readability by reducing each call site from ~30 lines to ~5 lines
- The actual differences between the two handlers (which textinput receives the path) are now clearly expressed via the closure parameter