### PR TITLE
feat: display remote server time and timezone in top bar

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -15,5 +15,6 @@ type Backend interface {
 	WriteHistory(jobID, jobName, output string, success bool) error
 	DeleteHistory(filePath string) error
 	EnsureRecordScript() error
+	GetTimezone() (string, int, error) // returns timezone name and offset in seconds
 	Close() error
 }

--- a/backend/file_backend.go
+++ b/backend/file_backend.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/swalha1999/lazycron/cron"
 	"github.com/swalha1999/lazycron/history"
@@ -93,5 +94,13 @@ func (b *FileBackend) DeleteHistory(filePath string) error {
 }
 
 func (b *FileBackend) EnsureRecordScript() error { return nil }
+
+// GetTimezone returns the local timezone name and UTC offset in seconds.
+func (b *FileBackend) GetTimezone() (string, int, error) {
+	now := time.Now()
+	_, offset := now.Zone()
+	tzName := now.Format("MST")
+	return tzName, offset, nil
+}
 
 func (b *FileBackend) Close() error { return nil }

--- a/backend/local.go
+++ b/backend/local.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/swalha1999/lazycron/cron"
 	"github.com/swalha1999/lazycron/history"
@@ -69,6 +70,14 @@ func (b *LocalBackend) DeleteHistory(filePath string) error {
 
 func (b *LocalBackend) EnsureRecordScript() error {
 	return record.InstallRecord()
+}
+
+// GetTimezone returns the local timezone name and UTC offset in seconds.
+func (b *LocalBackend) GetTimezone() (string, int, error) {
+	now := time.Now()
+	_, offset := now.Zone()
+	tzName := now.Format("MST")
+	return tzName, offset, nil
 }
 
 func (b *LocalBackend) Close() error { return nil }

--- a/backend/manager.go
+++ b/backend/manager.go
@@ -21,12 +21,14 @@ const (
 
 // ServerInfo holds metadata about a configured server.
 type ServerInfo struct {
-	Name   string
-	Host   string
-	Port   int
-	User   string
-	Status ConnStatus
-	Error  string
+	Name           string
+	Host           string
+	Port           int
+	User           string
+	Status         ConnStatus
+	Error          string
+	Timezone       string // e.g. "UTC", "EST", "PST"
+	TimezoneOffset int    // offset in seconds from UTC
 }
 
 // CachedData holds cached jobs and history for a server.
@@ -147,6 +149,16 @@ func (m *Manager) SetServerStatus(index int, status ConnStatus, errMsg string) {
 	if index >= 0 && index < len(m.servers) {
 		m.servers[index].Status = status
 		m.servers[index].Error = errMsg
+	}
+}
+
+// SetServerTimezone updates a server's timezone information.
+func (m *Manager) SetServerTimezone(index int, timezone string, offset int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if index >= 0 && index < len(m.servers) {
+		m.servers[index].Timezone = timezone
+		m.servers[index].TimezoneOffset = offset
 	}
 }
 

--- a/backend/manager_test.go
+++ b/backend/manager_test.go
@@ -22,6 +22,7 @@ func (m *mockBackend) LoadHistory() ([]history.Entry, error)                    
 func (m *mockBackend) WriteHistory(jobID, jobName, output string, ok bool) error { return nil }
 func (m *mockBackend) DeleteHistory(filePath string) error                 { return nil }
 func (m *mockBackend) EnsureRecordScript() error                           { return nil }
+func (m *mockBackend) GetTimezone() (string, int, error)                  { return "UTC", 0, nil }
 func (m *mockBackend) Close() error                                        { m.closed = true; return nil }
 
 // newTestManager creates a Manager with a mock local backend (avoids system crontab).

--- a/backend/remote.go
+++ b/backend/remote.go
@@ -220,6 +220,37 @@ func (b *RemoteBackend) DirLister() *RemoteDirLister {
 	return NewRemoteDirLister(b.client)
 }
 
+// GetTimezone returns the remote server's timezone name and UTC offset in seconds.
+func (b *RemoteBackend) GetTimezone() (string, int, error) {
+	// Get timezone offset in format like "+0200" or "-0500"
+	offsetStr, err := b.client.Run("date +%z")
+	if err != nil {
+		return "", 0, fmt.Errorf("get timezone offset: %w", err)
+	}
+	offsetStr = strings.TrimSpace(offsetStr)
+
+	// Get timezone name (e.g., "UTC", "EST")
+	tzName, err := b.client.Run("date +%Z")
+	if err != nil {
+		return "", 0, fmt.Errorf("get timezone name: %w", err)
+	}
+	tzName = strings.TrimSpace(tzName)
+
+	// Parse offset string (e.g., "+0200" -> 7200 seconds)
+	var offsetSeconds int
+	if len(offsetStr) == 5 && (offsetStr[0] == '+' || offsetStr[0] == '-') {
+		sign := 1
+		if offsetStr[0] == '-' {
+			sign = -1
+		}
+		var hours, minutes int
+		fmt.Sscanf(offsetStr[1:], "%2d%2d", &hours, &minutes)
+		offsetSeconds = sign * (hours*3600 + minutes*60)
+	}
+
+	return tzName, offsetSeconds, nil
+}
+
 func (b *RemoteBackend) Close() error {
 	return b.client.Close()
 }

--- a/ui/bars.go
+++ b/ui/bars.go
@@ -3,14 +3,37 @@ package ui
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/swalha1999/lazycron/backend"
 )
 
-func renderTopBar(m mode, serverName string, version string, width int) string {
+func renderTopBar(m mode, serverInfo backend.ServerInfo, version string, width int) string {
 	title := titleStyle.Render("lazycron")
 	versionTag := lipgloss.NewStyle().Foreground(colorMuted).Render(version)
-	serverTag := lipgloss.NewStyle().Foreground(colorCyan).Render("[" + serverName + "]")
+
+	// Build server tag with time and timezone
+	serverText := serverInfo.Name
+	if serverInfo.Timezone != "" {
+		// Calculate server time using the offset
+		now := time.Now().UTC()
+		serverTime := now.Add(time.Duration(serverInfo.TimezoneOffset) * time.Second)
+		timeStr := serverTime.Format("15:04")
+
+		// Format timezone offset (e.g., UTC+0, UTC+2, UTC-5)
+		offsetHours := serverInfo.TimezoneOffset / 3600
+		var tzStr string
+		if offsetHours >= 0 {
+			tzStr = fmt.Sprintf("%s+%d", serverInfo.Timezone, offsetHours)
+		} else {
+			tzStr = fmt.Sprintf("%s%d", serverInfo.Timezone, offsetHours)
+		}
+
+		serverText = fmt.Sprintf("%s • %s %s", serverInfo.Name, timeStr, tzStr)
+	}
+
+	serverTag := lipgloss.NewStyle().Foreground(colorCyan).Render("[" + serverText + "]")
 
 	var modeStr string
 	switch m {

--- a/ui/commands.go
+++ b/ui/commands.go
@@ -44,6 +44,8 @@ type clearStatusMsg struct {
 
 type historyTickMsg struct{}
 
+type timeTickMsg struct{}
+
 type splashDoneMsg struct{}
 
 // Server-related messages
@@ -71,6 +73,12 @@ func historyTick() tea.Cmd {
 	})
 }
 
+func timeTick() tea.Cmd {
+	return tea.Tick(time.Minute, func(time.Time) tea.Msg {
+		return timeTickMsg{}
+	})
+}
+
 func splashTimer() tea.Cmd {
 	return tea.Tick(1200*time.Millisecond, func(time.Time) tea.Msg {
 		return splashDoneMsg{}
@@ -79,7 +87,12 @@ func splashTimer() tea.Cmd {
 
 func (m Model) Init() tea.Cmd {
 	b := m.manager.ActiveBackend()
-	return tea.Batch(loadJobs(b), loadHistory(b), historyTick(), splashTimer())
+	// Get timezone for local server (index 0)
+	tzName, tzOffset, tzErr := b.GetTimezone()
+	if tzErr == nil {
+		m.manager.SetServerTimezone(0, tzName, tzOffset)
+	}
+	return tea.Batch(loadJobs(b), loadHistory(b), historyTick(), timeTick(), splashTimer())
 }
 
 // disableCompletedOneShotsMsg is sent after one-shot jobs have been auto-disabled.
@@ -188,6 +201,11 @@ func connectServerWithPassword(mgr *backend.Manager, index int, password string)
 		if err != nil {
 			mgr.SetServerStatus(index, backend.ConnError, err.Error())
 			return serverConnectedMsg{index: index, err: err}
+		}
+		// Get timezone information
+		tzName, tzOffset, tzErr := b.GetTimezone()
+		if tzErr == nil {
+			mgr.SetServerTimezone(index, tzName, tzOffset)
 		}
 		mgr.SetServerStatus(index, backend.ConnConnected, "")
 		return serverConnectedMsg{index: index, err: nil}

--- a/ui/update.go
+++ b/ui/update.go
@@ -49,6 +49,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		b := m.manager.ActiveBackend()
 		return m, tea.Batch(loadHistory(b), historyTick())
 
+	case timeTickMsg:
+		return m, timeTick()
+
 	case historyLoadedMsg:
 		if msg.err == nil {
 			m.history = msg.entries

--- a/ui/view.go
+++ b/ui/view.go
@@ -20,8 +20,8 @@ func (m Model) View() string {
 		return renderSplash(m.version, m.width, m.height)
 	}
 
-	serverName := m.manager.ServerAt(m.manager.ActiveIndex()).Name
-	topBar := renderTopBar(m.mode, serverName, m.version, m.width)
+	serverInfo := m.manager.ServerAt(m.manager.ActiveIndex())
+	topBar := renderTopBar(m.mode, serverInfo, m.version, m.width)
 
 	var searchView string
 	if m.mode == modeSearch {


### PR DESCRIPTION
Resolves #44

## Summary

When managing cron jobs across different timezones, it's easy to misconfigure schedules. This PR displays the remote server's current time and timezone offset in the top bar next to the server name, making it immediately obvious what time it is on the server.

## Changes

- Add `Timezone` and `TimezoneOffset` fields to `ServerInfo` struct
- Query timezone from remote servers using `date +%z` and `date +%Z`
- Get local timezone using Go's `time.Now().Zone()`
- Display server time and timezone in top bar (e.g., `[local • 14:23 PST-8]`)
- Add time tick to update display every minute
- Implement `GetTimezone()` method in all `Backend` implementations

## Example

**Before:**
```
lazycron v0.x.x  [CronWorker]                          NORMAL
```

**After:**
```
lazycron v0.x.x  [CronWorker • 05:36 UTC+0]            NORMAL
```

## Test plan
- [x] Build succeeds
- [x] All tests pass
- [x] Timezone is queried correctly on server connect
- [x] Time updates every minute via tick
- [x] Display format matches the proposal in issue #44