### PR TITLE
Feat #42: environment variable support in sync YAML files

### DIFF
--- a/cmd/pull_test.go
+++ b/cmd/pull_test.go
@@ -264,7 +264,7 @@ func TestWriteJobYAML_RoundTrip(t *testing.T) {
 	}
 
 	// Read back using the sync command's readJobFiles.
-	jobs, err := readJobFiles(dir)
+	jobs, err := readJobFiles(dir, nil)
 	if err != nil {
 		t.Fatalf("readJobFiles: %v", err)
 	}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -10,6 +10,7 @@ import (
 	"github.com/swalha1999/lazycron/backend"
 	"github.com/swalha1999/lazycron/config"
 	"github.com/swalha1999/lazycron/cron"
+	"github.com/swalha1999/lazycron/envsubst"
 	"github.com/swalha1999/lazycron/record"
 	sshclient "github.com/swalha1999/lazycron/ssh"
 	"gopkg.in/yaml.v3"
@@ -25,11 +26,13 @@ var syncCmd = &cobra.Command{
 var (
 	syncServer string
 	syncDir    string
+	syncVars   []string
 )
 
 func init() {
 	syncCmd.Flags().StringVarP(&syncServer, "server", "s", "", "target server name from config")
 	syncCmd.Flags().StringVar(&syncDir, "dir", "", "path to .lazycron directory (default: ./.lazycron)")
+	syncCmd.Flags().StringArrayVar(&syncVars, "var", nil, "variable substitution in KEY=VALUE format (can be repeated)")
 	rootCmd.AddCommand(syncCmd)
 }
 
@@ -58,8 +61,15 @@ func runSync(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no jobs directory found at %s", jobsDir)
 	}
 
+	// Build variable map for substitution.
+	envFile := filepath.Join(dir, ".env")
+	vars, err := envsubst.BuildVarMap(syncVars, envFile)
+	if err != nil {
+		return err
+	}
+
 	// Read YAML job files.
-	incoming, err := readJobFiles(jobsDir)
+	incoming, err := readJobFiles(jobsDir, vars)
 	if err != nil {
 		return err
 	}
@@ -96,7 +106,8 @@ func runSync(cmd *cobra.Command, args []string) error {
 
 // readJobFiles reads all .yaml files from dir and returns them as cron.Jobs.
 // The filename (minus .yaml) is used as the job ID.
-func readJobFiles(dir string) ([]cron.Job, error) {
+// If vars is non-nil, ${VAR} references in file content are substituted.
+func readJobFiles(dir string, vars map[string]string) ([]cron.Job, error) {
 	files, err := filepath.Glob(filepath.Join(dir, "*.yaml"))
 	if err != nil {
 		return nil, err
@@ -114,8 +125,16 @@ func readJobFiles(dir string) ([]cron.Job, error) {
 			return nil, fmt.Errorf("reading %s: %w", filepath.Base(f), err)
 		}
 
+		content := string(data)
+		if vars != nil {
+			content, err = envsubst.Substitute(content, vars)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", filepath.Base(f), err)
+			}
+		}
+
 		var jf jobFile
-		if err := yaml.Unmarshal(data, &jf); err != nil {
+		if err := yaml.Unmarshal([]byte(content), &jf); err != nil {
 			return nil, fmt.Errorf("parsing %s: %w", filepath.Base(f), err)
 		}
 

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -28,7 +28,7 @@ schedule: "0 0 * * 0"
 command: logrotate /etc/logrotate.conf
 `)
 
-	jobs, err := readJobFiles(dir)
+	jobs, err := readJobFiles(dir, nil)
 	if err != nil {
 		t.Fatalf("readJobFiles: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestReadJobFiles_InvalidYAML(t *testing.T) {
 	dir := t.TempDir()
 	writeYAML(t, dir, "bad-job.yaml", `not: valid: yaml: [`)
 
-	_, err := readJobFiles(dir)
+	_, err := readJobFiles(dir, nil)
 	if err == nil {
 		t.Fatal("expected error for invalid YAML")
 	}
@@ -81,7 +81,7 @@ schedule: "* * * * *"
 command: echo hi
 `)
 
-	_, err := readJobFiles(dir)
+	_, err := readJobFiles(dir, nil)
 	if err == nil {
 		t.Fatal("expected error for uppercase filename")
 	}
@@ -94,7 +94,7 @@ schedule: "* * * * *"
 command: echo hi
 `)
 
-	_, err := readJobFiles(dir)
+	_, err := readJobFiles(dir, nil)
 	if err == nil {
 		t.Fatal("expected error for missing name")
 	}
@@ -102,7 +102,7 @@ command: echo hi
 
 func TestReadJobFiles_EmptyDir(t *testing.T) {
 	dir := t.TempDir()
-	jobs, err := readJobFiles(dir)
+	jobs, err := readJobFiles(dir, nil)
 	if err != nil {
 		t.Fatalf("readJobFiles: %v", err)
 	}
@@ -120,7 +120,7 @@ command: echo off
 enabled: false
 `)
 
-	jobs, err := readJobFiles(dir)
+	jobs, err := readJobFiles(dir, nil)
 	if err != nil {
 		t.Fatalf("readJobFiles: %v", err)
 	}
@@ -129,6 +129,71 @@ enabled: false
 	}
 	if jobs[0].Enabled {
 		t.Error("expected enabled=false")
+	}
+}
+
+// --- readJobFiles with env vars ---
+
+func TestReadJobFiles_EnvSubstitution(t *testing.T) {
+	dir := t.TempDir()
+
+	writeYAML(t, dir, "db-backup.yaml", `
+name: Database Backup
+schedule: "0 3 * * *"
+command: pg_dump -h ${DB_HOST} ${DB_NAME}
+`)
+
+	vars := map[string]string{
+		"DB_HOST": "prod-db.example.com",
+		"DB_NAME": "appdb",
+	}
+
+	jobs, err := readJobFiles(dir, vars)
+	if err != nil {
+		t.Fatalf("readJobFiles: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	want := "pg_dump -h prod-db.example.com appdb"
+	if jobs[0].Command != want {
+		t.Errorf("command = %q, want %q", jobs[0].Command, want)
+	}
+}
+
+func TestReadJobFiles_UndefinedVarError(t *testing.T) {
+	dir := t.TempDir()
+
+	writeYAML(t, dir, "db-backup.yaml", `
+name: Database Backup
+schedule: "0 3 * * *"
+command: pg_dump -h ${DB_HOST} ${DB_NAME}
+`)
+
+	vars := map[string]string{"DB_HOST": "localhost"}
+
+	_, err := readJobFiles(dir, vars)
+	if err == nil {
+		t.Fatal("expected error for undefined variable")
+	}
+}
+
+func TestReadJobFiles_NilVarsSkipsSubstitution(t *testing.T) {
+	dir := t.TempDir()
+
+	writeYAML(t, dir, "job.yaml", `
+name: Test Job
+schedule: "* * * * *"
+command: echo ${NOT_SUBSTITUTED}
+`)
+
+	// nil vars means no substitution — ${...} is preserved as-is.
+	jobs, err := readJobFiles(dir, nil)
+	if err != nil {
+		t.Fatalf("readJobFiles: %v", err)
+	}
+	if jobs[0].Command != "echo ${NOT_SUBSTITUTED}" {
+		t.Errorf("command = %q, expected literal ${NOT_SUBSTITUTED}", jobs[0].Command)
 	}
 }
 

--- a/envsubst/envsubst.go
+++ b/envsubst/envsubst.go
@@ -1,0 +1,118 @@
+package envsubst
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// varPattern matches ${VAR_NAME} references in text.
+var varPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
+
+// Substitute replaces all ${VAR} references in content using the provided
+// variable map. Returns an error if any referenced variable is not defined.
+func Substitute(content string, vars map[string]string) (string, error) {
+	var missing []string
+
+	result := varPattern.ReplaceAllStringFunc(content, func(match string) string {
+		name := varPattern.FindStringSubmatch(match)[1]
+		if val, ok := vars[name]; ok {
+			return val
+		}
+		missing = append(missing, name)
+		return match
+	})
+
+	if len(missing) > 0 {
+		return "", fmt.Errorf("undefined variables: %s", strings.Join(missing, ", "))
+	}
+
+	return result, nil
+}
+
+// ParseEnvFile reads a .env file and returns key=value pairs.
+// Empty lines and lines starting with # are ignored.
+func ParseEnvFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	vars := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	lineNum := 0
+
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		key, val, ok := strings.Cut(line, "=")
+		if !ok {
+			return nil, fmt.Errorf("%s:%d: invalid line (expected KEY=VALUE)", path, lineNum)
+		}
+
+		key = strings.TrimSpace(key)
+		val = strings.TrimSpace(val)
+
+		// Strip optional surrounding quotes.
+		if len(val) >= 2 {
+			if (val[0] == '"' && val[len(val)-1] == '"') || (val[0] == '\'' && val[len(val)-1] == '\'') {
+				val = val[1 : len(val)-1]
+			}
+		}
+
+		vars[key] = val
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	return vars, nil
+}
+
+// BuildVarMap builds a variable map by merging sources in priority order:
+//  1. flagVars (--var KEY=VALUE flags, highest priority)
+//  2. envFile (.lazycron/.env file, if it exists)
+//  3. os.Environ (shell environment, lowest priority)
+func BuildVarMap(flagVars []string, envFilePath string) (map[string]string, error) {
+	vars := make(map[string]string)
+
+	// Layer 3: shell environment (lowest priority).
+	for _, env := range os.Environ() {
+		if key, val, ok := strings.Cut(env, "="); ok {
+			vars[key] = val
+		}
+	}
+
+	// Layer 2: .env file (overrides shell env).
+	if envFilePath != "" {
+		if _, err := os.Stat(envFilePath); err == nil {
+			envVars, err := ParseEnvFile(envFilePath)
+			if err != nil {
+				return nil, err
+			}
+			for k, v := range envVars {
+				vars[k] = v
+			}
+		}
+	}
+
+	// Layer 1: --var flags (highest priority).
+	for _, fv := range flagVars {
+		key, val, ok := strings.Cut(fv, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid --var format %q (expected KEY=VALUE)", fv)
+		}
+		vars[strings.TrimSpace(key)] = strings.TrimSpace(val)
+	}
+
+	return vars, nil
+}

--- a/envsubst/envsubst_test.go
+++ b/envsubst/envsubst_test.go
@@ -1,0 +1,254 @@
+package envsubst
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- Substitute ---
+
+func TestSubstitute_Basic(t *testing.T) {
+	vars := map[string]string{
+		"DB_HOST": "localhost",
+		"DB_NAME": "mydb",
+	}
+	input := "pg_dump -h ${DB_HOST} ${DB_NAME}"
+	got, err := Substitute(input, vars)
+	if err != nil {
+		t.Fatalf("Substitute: %v", err)
+	}
+	want := "pg_dump -h localhost mydb"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSubstitute_NoVars(t *testing.T) {
+	input := "echo hello world"
+	got, err := Substitute(input, map[string]string{})
+	if err != nil {
+		t.Fatalf("Substitute: %v", err)
+	}
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestSubstitute_UndefinedVar(t *testing.T) {
+	vars := map[string]string{"DB_HOST": "localhost"}
+	input := "pg_dump -h ${DB_HOST} ${DB_NAME}"
+	_, err := Substitute(input, vars)
+	if err == nil {
+		t.Fatal("expected error for undefined variable")
+	}
+	if !strings.Contains(err.Error(), "DB_NAME") {
+		t.Errorf("error should mention DB_NAME: %v", err)
+	}
+}
+
+func TestSubstitute_MultipleUndefined(t *testing.T) {
+	input := "${A} ${B} ${C}"
+	_, err := Substitute(input, map[string]string{})
+	if err == nil {
+		t.Fatal("expected error for undefined variables")
+	}
+	for _, name := range []string{"A", "B", "C"} {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("error should mention %s: %v", name, err)
+		}
+	}
+}
+
+func TestSubstitute_RepeatedVar(t *testing.T) {
+	vars := map[string]string{"X": "42"}
+	input := "${X} and ${X}"
+	got, err := Substitute(input, vars)
+	if err != nil {
+		t.Fatalf("Substitute: %v", err)
+	}
+	if got != "42 and 42" {
+		t.Errorf("got %q, want %q", got, "42 and 42")
+	}
+}
+
+func TestSubstitute_PreservesNonVarDollar(t *testing.T) {
+	vars := map[string]string{}
+	// $FOO (no braces) should not be substituted.
+	input := "date +%F $HOME"
+	got, err := Substitute(input, vars)
+	if err != nil {
+		t.Fatalf("Substitute: %v", err)
+	}
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+// --- ParseEnvFile ---
+
+func TestParseEnvFile_Basic(t *testing.T) {
+	content := "DB_HOST=localhost\nDB_NAME=mydb\nBACKUP_DIR=/backups\n"
+	path := writeEnvFile(t, content)
+
+	vars, err := ParseEnvFile(path)
+	if err != nil {
+		t.Fatalf("ParseEnvFile: %v", err)
+	}
+
+	want := map[string]string{
+		"DB_HOST":    "localhost",
+		"DB_NAME":    "mydb",
+		"BACKUP_DIR": "/backups",
+	}
+	for k, v := range want {
+		if vars[k] != v {
+			t.Errorf("vars[%q] = %q, want %q", k, vars[k], v)
+		}
+	}
+}
+
+func TestParseEnvFile_CommentsAndBlankLines(t *testing.T) {
+	content := "# This is a comment\n\nDB_HOST=localhost\n  # Another comment\n\nDB_NAME=mydb\n"
+	path := writeEnvFile(t, content)
+
+	vars, err := ParseEnvFile(path)
+	if err != nil {
+		t.Fatalf("ParseEnvFile: %v", err)
+	}
+	if len(vars) != 2 {
+		t.Errorf("expected 2 vars, got %d", len(vars))
+	}
+}
+
+func TestParseEnvFile_QuotedValues(t *testing.T) {
+	content := `DB_HOST="localhost"
+DB_NAME='mydb'
+PLAIN=value
+`
+	path := writeEnvFile(t, content)
+
+	vars, err := ParseEnvFile(path)
+	if err != nil {
+		t.Fatalf("ParseEnvFile: %v", err)
+	}
+
+	if vars["DB_HOST"] != "localhost" {
+		t.Errorf("DB_HOST = %q, want %q", vars["DB_HOST"], "localhost")
+	}
+	if vars["DB_NAME"] != "mydb" {
+		t.Errorf("DB_NAME = %q, want %q", vars["DB_NAME"], "mydb")
+	}
+	if vars["PLAIN"] != "value" {
+		t.Errorf("PLAIN = %q, want %q", vars["PLAIN"], "value")
+	}
+}
+
+func TestParseEnvFile_ValueWithEquals(t *testing.T) {
+	content := "CONNECTION=host=localhost dbname=mydb\n"
+	path := writeEnvFile(t, content)
+
+	vars, err := ParseEnvFile(path)
+	if err != nil {
+		t.Fatalf("ParseEnvFile: %v", err)
+	}
+	if vars["CONNECTION"] != "host=localhost dbname=mydb" {
+		t.Errorf("CONNECTION = %q", vars["CONNECTION"])
+	}
+}
+
+func TestParseEnvFile_InvalidLine(t *testing.T) {
+	content := "not-a-valid-line\n"
+	path := writeEnvFile(t, content)
+
+	_, err := ParseEnvFile(path)
+	if err == nil {
+		t.Fatal("expected error for invalid line")
+	}
+}
+
+func TestParseEnvFile_NotFound(t *testing.T) {
+	_, err := ParseEnvFile("/nonexistent/.env")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+// --- BuildVarMap ---
+
+func TestBuildVarMap_FlagOverridesEnvFile(t *testing.T) {
+	envContent := "DB_HOST=from-env-file\n"
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envPath, []byte(envContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	vars, err := BuildVarMap([]string{"DB_HOST=from-flag"}, envPath)
+	if err != nil {
+		t.Fatalf("BuildVarMap: %v", err)
+	}
+	if vars["DB_HOST"] != "from-flag" {
+		t.Errorf("DB_HOST = %q, want %q", vars["DB_HOST"], "from-flag")
+	}
+}
+
+func TestBuildVarMap_EnvFileOverridesShell(t *testing.T) {
+	t.Setenv("TEST_LAZYCRON_VAR", "from-shell")
+
+	envContent := "TEST_LAZYCRON_VAR=from-env-file\n"
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envPath, []byte(envContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	vars, err := BuildVarMap(nil, envPath)
+	if err != nil {
+		t.Fatalf("BuildVarMap: %v", err)
+	}
+	if vars["TEST_LAZYCRON_VAR"] != "from-env-file" {
+		t.Errorf("TEST_LAZYCRON_VAR = %q, want %q", vars["TEST_LAZYCRON_VAR"], "from-env-file")
+	}
+}
+
+func TestBuildVarMap_ShellEnvFallback(t *testing.T) {
+	t.Setenv("TEST_LAZYCRON_SHELL", "from-shell")
+
+	vars, err := BuildVarMap(nil, "")
+	if err != nil {
+		t.Fatalf("BuildVarMap: %v", err)
+	}
+	if vars["TEST_LAZYCRON_SHELL"] != "from-shell" {
+		t.Errorf("TEST_LAZYCRON_SHELL = %q, want %q", vars["TEST_LAZYCRON_SHELL"], "from-shell")
+	}
+}
+
+func TestBuildVarMap_MissingEnvFileIgnored(t *testing.T) {
+	vars, err := BuildVarMap(nil, "/nonexistent/.env")
+	if err != nil {
+		t.Fatalf("BuildVarMap: %v", err)
+	}
+	if vars == nil {
+		t.Fatal("expected non-nil map")
+	}
+}
+
+func TestBuildVarMap_InvalidFlagFormat(t *testing.T) {
+	_, err := BuildVarMap([]string{"NOEQUALS"}, "")
+	if err == nil {
+		t.Fatal("expected error for invalid --var format")
+	}
+}
+
+// --- helpers ---
+
+func writeEnvFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}


### PR DESCRIPTION
Closes #42

## Summary
- Add `${VAR}` substitution in `.lazycron/jobs/*.yaml` files during `lazycron sync`
- Variables resolved in priority order: `--var` flags > `.lazycron/.env` file > shell environment
- Undefined variables produce a clear error listing all missing names
- New `envsubst` package with `Substitute`, `ParseEnvFile`, and `BuildVarMap` functions

## Changes
- **`envsubst/envsubst.go`** — new package for variable substitution and .env file parsing
- **`envsubst/envsubst_test.go`** — comprehensive tests for substitution, .env parsing, and var map building
- **`cmd/sync.go`** — added `--var` flag, .env file loading, and substitution before YAML parsing
- **`cmd/sync_test.go`** — added tests for env var substitution in readJobFiles
- **`cmd/pull_test.go`** — updated readJobFiles call signature

## Usage
```bash
# Using --var flags
lazycron sync --var DB_HOST=localhost --var DB_NAME=mydb

# Using .lazycron/.env file
echo "DB_HOST=localhost" > .lazycron/.env
lazycron sync

# Falls back to shell environment
export DB_HOST=localhost
lazycron sync
```

## Test plan
- [x] All existing tests pass with updated readJobFiles signature
- [x] New envsubst package tests cover: basic substitution, undefined vars, repeated vars, non-var dollar signs, .env parsing with comments/quotes/equals-in-values, priority ordering (flag > .env > shell), missing .env gracefully ignored, invalid --var format error
- [x] New sync_test.go tests cover: substitution in YAML files, undefined var errors, nil vars skips substitution
- [x] `go vet ./...` passes
- [x] `go build ./...` passes