### PR TITLE
Fix #51: add path traversal protection to RemoteBackend.DeleteHistory

### DIFF
--- a/backend/remote.go
+++ b/backend/remote.go
@@ -191,7 +191,24 @@ func (b *RemoteBackend) WriteHistory(jobID, jobName, output string, success bool
 }
 
 func (b *RemoteBackend) DeleteHistory(filePath string) error {
-	_, err := b.client.Run("rm -f " + shellQuote(filePath))
+	lcDir, err := b.lazycronDir()
+	if err != nil {
+		return fmt.Errorf("failed to resolve history dir: %w", err)
+	}
+	historyDir := lcDir + "/history"
+
+	// Clean the path and verify it stays within the history directory.
+	cleaned := filepath.Clean(filePath)
+	rel, err := filepath.Rel(historyDir, cleaned)
+	if err != nil {
+		return fmt.Errorf("refusing to delete file outside history dir")
+	}
+	if strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return fmt.Errorf("refusing to delete file outside history dir")
+	}
+
+	safePath := historyDir + "/" + rel
+	_, err = b.client.Run("rm -f " + shellQuote(safePath))
 	return err
 }
 


### PR DESCRIPTION
Closes #51

## Summary

`RemoteBackend.DeleteHistory()` in `backend/remote.go` passed the user-supplied `filePath` directly to `rm -f` over SSH without validating it stays within the history directory. This allowed potential deletion of arbitrary files on the remote system.

This fix adds the same path traversal protection already present in `FileBackend` and `LocalBackend`: clean the path, compute the relative path from the history directory, reject paths that escape with `..`, and reconstruct a safe absolute path before deletion.

Note: `LocalBackend.DeleteHistory()` was already fixed (contrary to the issue description which references older code).