### PR TITLE
Fix #63: Quote shell arguments to prevent command injection

### DIFF
--- a/backend/remote.go
+++ b/backend/remote.go
@@ -85,7 +85,7 @@ func (b *RemoteBackend) WriteJobs(jobs []cron.Job) error {
 	remoteScriptsDir := lcDir + "/scripts"
 
 	// Ensure scripts directory exists on remote.
-	if _, err := b.client.Run("mkdir -p " + remoteScriptsDir); err != nil {
+	if _, err := b.client.Run("mkdir -p " + shellQuote(remoteScriptsDir)); err != nil {
 		return fmt.Errorf("create scripts dir: %w", err)
 	}
 
@@ -224,7 +224,7 @@ func (b *RemoteBackend) EnsureRecordScript() error {
 
 	// Create directories
 	_, err = b.client.Run(fmt.Sprintf("mkdir -p %s/bin %s/history %s/scripts",
-		lcDir, lcDir, lcDir))
+		shellQuote(lcDir), shellQuote(lcDir), shellQuote(lcDir)))
 	if err != nil {
 		return fmt.Errorf("create dirs: %w", err)
 	}


### PR DESCRIPTION
Closes #63

## Summary
Added `shellQuote()` to two unquoted path arguments in `backend/remote.go` that were vulnerable to command injection via crafted `$HOME` values from a remote SSH server.

## Changes
- **Line 88**: `mkdir -p` for scripts directory now uses `shellQuote(remoteScriptsDir)`
- **Lines 226-227**: `mkdir -p` for lazycron subdirectories now uses `shellQuote(lcDir)` for all three interpolations

These two locations were the only places missing `shellQuote()` — all other shell commands in the file already used it correctly.