### PR TITLE
fix: allow undefined variables in sync command

### DIFF
--- a/envsubst/envsubst.go
+++ b/envsubst/envsubst.go
@@ -12,22 +12,17 @@ import (
 var varPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
 
 // Substitute replaces all ${VAR} references in content using the provided
-// variable map. Returns an error if any referenced variable is not defined.
+// variable map. Variables not found in the map are left unchanged (allowing
+// bash variables and other runtime variables to pass through).
 func Substitute(content string, vars map[string]string) (string, error) {
-	var missing []string
-
 	result := varPattern.ReplaceAllStringFunc(content, func(match string) string {
 		name := varPattern.FindStringSubmatch(match)[1]
 		if val, ok := vars[name]; ok {
 			return val
 		}
-		missing = append(missing, name)
+		// Leave undefined variables unchanged (e.g., bash variables)
 		return match
 	})
-
-	if len(missing) > 0 {
-		return "", fmt.Errorf("undefined variables: %s", strings.Join(missing, ", "))
-	}
 
 	return result, nil
 }

--- a/envsubst/envsubst_test.go
+++ b/envsubst/envsubst_test.go
@@ -3,7 +3,6 @@ package envsubst
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -39,25 +38,26 @@ func TestSubstitute_NoVars(t *testing.T) {
 func TestSubstitute_UndefinedVar(t *testing.T) {
 	vars := map[string]string{"DB_HOST": "localhost"}
 	input := "pg_dump -h ${DB_HOST} ${DB_NAME}"
-	_, err := Substitute(input, vars)
-	if err == nil {
-		t.Fatal("expected error for undefined variable")
+	got, err := Substitute(input, vars)
+	if err != nil {
+		t.Fatalf("Substitute: %v", err)
 	}
-	if !strings.Contains(err.Error(), "DB_NAME") {
-		t.Errorf("error should mention DB_NAME: %v", err)
+	// Undefined variables should be left unchanged
+	want := "pg_dump -h localhost ${DB_NAME}"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }
 
 func TestSubstitute_MultipleUndefined(t *testing.T) {
 	input := "${A} ${B} ${C}"
-	_, err := Substitute(input, map[string]string{})
-	if err == nil {
-		t.Fatal("expected error for undefined variables")
+	got, err := Substitute(input, map[string]string{})
+	if err != nil {
+		t.Fatalf("Substitute: %v", err)
 	}
-	for _, name := range []string{"A", "B", "C"} {
-		if !strings.Contains(err.Error(), name) {
-			t.Errorf("error should mention %s: %v", name, err)
-		}
+	// Undefined variables should be left unchanged
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
 	}
 }
 


### PR DESCRIPTION
## Problem

The `sync` command was failing with error: `undefined variables: ISSUE, ISSUE, ISSUE...` when syncing job files like `fix-agent.yaml`.

The issue occurred because job YAML files contain bash variables (e.g., `${ISSUE}`) that are defined and used at runtime within the command script itself, but the `envsubst.Substitute()` function was treating ALL `${VAR}` patterns as template variables and erroring if they weren't defined in the variable map.

## Solution

Modified `envsubst.Substitute()` to leave undefined variables unchanged instead of returning an error. This allows:
- **Template variables** to be substituted at sync time (from `.env`, `--var` flags, or environment)
- **Bash variables** to pass through unchanged for runtime evaluation

## Changes

- Updated `envsubst.Substitute()` to skip undefined variables instead of erroring
- Modified tests to verify undefined variables are preserved correctly
- Removed unused `strings` import from test file

## Testing

- All tests pass: `go test ./envsubst/...`
- Verified `lazycron sync` now works successfully with `fix-agent.yaml` and other job files
- Confirmed 6 jobs sync without errors

Fixes the sync command to properly handle bash variables in job definitions.