### PR TITLE
Feat #33: Swallow non-zero exit codes from shell profile sourcing

### DIFF
--- a/cron/scripts.go
+++ b/cron/scripts.go
@@ -35,7 +35,7 @@ func WriteScript(jobID, command string) error {
 // ScriptPreamble is the profile-sourcing block prepended to every script.
 const ScriptPreamble = "# Source user profile for PATH and environment variables.\n" +
 	"for __lc_rc in \"$HOME/.profile\" \"$HOME/.bashrc\" \"$HOME/.zshrc\"; do\n" +
-	"  [ -f \"$__lc_rc\" ] && . \"$__lc_rc\" 2>/dev/null\n" +
+	"  [ -f \"$__lc_rc\" ] && . \"$__lc_rc\" 2>/dev/null || true\n" +
 	"done\n" +
 	"unset __lc_rc\n"
 


### PR DESCRIPTION
Closes #33

## Summary
- Added `|| true` to the profile-sourcing line in `ScriptPreamble` so that non-zero exit codes from sourcing `~/.zshrc` (or other shell profiles) under `/bin/sh` are swallowed
- This prevents `lazycron run` from reporting failure when the actual job command succeeds

## Details
The script preamble sources `~/.profile`, `~/.bashrc`, and `~/.zshrc` to pick up PATH and environment variables. When `~/.zshrc` contains zsh-specific syntax (`autoload`, `compinit`, plugins, etc.), sourcing it under `/bin/sh` fails. The existing `2>/dev/null` hides stderr but the non-zero exit code still propagates.

## Test plan
- [x] All existing `cron` package tests pass
- [x] `StripShebang` round-trips correctly with the updated preamble
- [x] Build compiles cleanly