### PR TITLE
Feat #33: Swallow non-zero exit codes from shell profile sourcing

### DIFF
--- a/cron/scripts.go
+++ b/cron/scripts.go
@@ -35,7 +35,7 @@ func WriteScript(jobID, command string) error {
 // ScriptPreamble is the profile-sourcing block prepended to every script.
 const ScriptPreamble = "# Source user profile for PATH and environment variables.\n" +
 	"for __lc_rc in \"$HOME/.profile\" \"$HOME/.bashrc\" \"$HOME/.zshrc\"; do\n" +
-	"  [ -f \"$__lc_rc\" ] && . \"$__lc_rc\" 2>/dev/null\n" +
+	"  [ -f \"$__lc_rc\" ] && . \"$__lc_rc\" 2>/dev/null || true\n" +
 	"done\n" +
 	"unset __lc_rc\n"
 


### PR DESCRIPTION
Closes #33

## Summary
- Added `|| true` to the profile-sourcing loop in `ScriptPreamble` so that non-zero exit codes from sourcing `~/.zshrc` (or other RC files with shell-specific syntax) are swallowed
- Previously, zsh-specific syntax (`autoload`, `compinit`, plugins, etc.) would fail under `/bin/sh`, and while `2>/dev/null` hid the stderr output, the non-zero exit code still propagated, causing `lazycron run` to report failure even when the actual job command succeeded

## Changes
- `cron/scripts.go`: Changed `[ -f "$__lc_rc" ] && . "$__lc_rc" 2>/dev/null` to `[ -f "$__lc_rc" ] && . "$__lc_rc" 2>/dev/null || true`