### PR TITLE
fix: pin sandcastle agent PROJECT_NAME so the right docker image runs

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -75,7 +75,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	if withAgents {
-		if err := scaffoldSandcastle(cwd); err != nil {
+		if err := scaffoldSandcastle(cwd, name); err != nil {
 			return err
 		}
 	}
@@ -91,8 +91,8 @@ func runInit(cmd *cobra.Command, args []string) error {
 // sandbox, GitHub Issues backlog. The Dockerfile, .env.example, and
 // in-folder .gitignore are pinned copies of @ai-hero/sandcastle@0.5.7's
 // blank-template output for that combination.
-func scaffoldSandcastle(cwd string) error {
-	if err := scaffoldSandcastleConfig(cwd); err != nil {
+func scaffoldSandcastle(cwd, projectName string) error {
+	if err := scaffoldSandcastleConfig(cwd, projectName); err != nil {
 		return fmt.Errorf("scaffold .sandcastle/: %w", err)
 	}
 
@@ -114,7 +114,7 @@ func scaffoldSandcastle(cwd string) error {
 // realScaffoldSandcastleConfig writes the embedded Dockerfile, .env.example,
 // and .gitignore into .sandcastle/. Existing files are not overwritten so
 // re-running with --force preserves user edits.
-func realScaffoldSandcastleConfig(cwd string) error {
+func realScaffoldSandcastleConfig(cwd, projectName string) error {
 	sandcastleDir := filepath.Join(cwd, ".sandcastle")
 	if err := os.MkdirAll(sandcastleDir, 0o755); err != nil {
 		return err
@@ -136,7 +136,9 @@ func realScaffoldSandcastleConfig(cwd string) error {
 		// surfaces "set REPO_URL in .sandcastle/.env" instead of "no such
 		// file" the first time the user runs an agent. Skipped if .env
 		// already exists. If we found a git remote, pre-fill REPO_URL.
-		{"sandcastle_init/env.example", ".env", fillRepoURL(repoURL)},
+		// PROJECT_NAME is also pre-filled so the agent's cache dir and the
+		// sandcastle Docker image tag stay aligned with the lazycron project.
+		{"sandcastle_init/env.example", ".env", composeEnvTransforms(fillRepoURL(repoURL), fillProjectName(projectName))},
 		{"sandcastle_init/gitignore", ".gitignore", nil},
 		{"sandcastle_init/package.json", "package.json", nil},
 	}
@@ -185,6 +187,36 @@ func fillRepoURL(url string) func([]byte) []byte {
 		// Only replace when the line is empty (REPO_URL=\n), so we don't
 		// accidentally clobber a value the user already set in env.example.
 		return bytes.Replace(data, []byte("REPO_URL=\n"), []byte("REPO_URL="+url+"\n"), 1)
+	}
+}
+
+// fillProjectName returns a transform that replaces the `PROJECT_NAME=` line
+// in .env contents with `PROJECT_NAME=<name>`. No-op if name is empty.
+func fillProjectName(name string) func([]byte) []byte {
+	if name == "" {
+		return nil
+	}
+	return func(data []byte) []byte {
+		return bytes.Replace(data, []byte("PROJECT_NAME=\n"), []byte("PROJECT_NAME="+name+"\n"), 1)
+	}
+}
+
+// composeEnvTransforms chains a sequence of optional transforms (any may be nil).
+func composeEnvTransforms(fns ...func([]byte) []byte) func([]byte) []byte {
+	var active []func([]byte) []byte
+	for _, fn := range fns {
+		if fn != nil {
+			active = append(active, fn)
+		}
+	}
+	if len(active) == 0 {
+		return nil
+	}
+	return func(data []byte) []byte {
+		for _, fn := range active {
+			data = fn(data)
+		}
+		return data
 	}
 }
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -24,7 +24,7 @@ func chdirTemp(t *testing.T) string {
 }
 
 // stubInit replaces scaffoldSandcastleConfig + writeEnsureRepoLib for tests, restoring on cleanup.
-func stubInit(t *testing.T, scaffold func(string) error, write func(string) error) {
+func stubInit(t *testing.T, scaffold func(string, string) error, write func(string) error) {
 	t.Helper()
 	origScaffold := scaffoldSandcastleConfig
 	origWrite := writeEnsureRepoLib
@@ -142,10 +142,13 @@ func TestRunInit_WithAgents_StubbedHooks(t *testing.T) {
 	// unresolved form but os.Getwd inside runInit returns the resolved one.
 	resolvedDir, _ := filepath.EvalSymlinks(dir)
 	stubInit(t,
-		func(cwd string) error {
+		func(cwd, projectName string) error {
 			scaffoldCalls++
 			if cwd != resolvedDir && cwd != dir {
 				t.Errorf("scaffold called with cwd %q, want %q (or %q)", cwd, resolvedDir, dir)
+			}
+			if projectName != "agents-test" {
+				t.Errorf("scaffold called with projectName %q, want %q", projectName, "agents-test")
 			}
 			return os.MkdirAll(filepath.Join(cwd, ".sandcastle"), 0o755)
 		},

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -74,6 +74,14 @@ func runSync(cmd *cobra.Command, args []string) error {
 	}
 	projectName := config.ResolveProjectName(syncProject, pcfg, cwd)
 
+	// Ensure .sandcastle/.env has PROJECT_NAME. The agent reads this to align
+	// its cache dir (~/.lazycron-cache/repos/<name>) and sandcastle Docker image
+	// tag with the lazycron project — missing it lands on a hard-coded default
+	// and silently runs the wrong cached repo / image.
+	if err := ensureSandcastleEnvProjectName(sandcastleDir, projectName); err != nil {
+		return fmt.Errorf("update .sandcastle/.env: %w", err)
+	}
+
 	// Read TS jobs.
 	incoming, err := readSandcastleJobs(jobsDir, projectName)
 	if err != nil {
@@ -220,6 +228,47 @@ func readSandcastleJobs(jobsDir, projectName string) ([]cron.Job, error) {
 		})
 	}
 	return jobs, nil
+}
+
+// ensureSandcastleEnvProjectName makes sure .sandcastle/.env contains a
+// PROJECT_NAME entry pointing at projectName. Existing values are left
+// untouched; a missing key (or missing file) is added. Idempotent.
+func ensureSandcastleEnvProjectName(sandcastleDir, projectName string) error {
+	if projectName == "" {
+		return nil
+	}
+	envPath := filepath.Join(sandcastleDir, ".env")
+	data, err := os.ReadFile(envPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "PROJECT_NAME=") {
+			return nil
+		}
+	}
+
+	if err := os.MkdirAll(sandcastleDir, 0o755); err != nil {
+		return err
+	}
+
+	prefix := ""
+	if len(data) > 0 && !strings.HasSuffix(string(data), "\n") {
+		prefix = "\n"
+	}
+	addition := prefix + "PROJECT_NAME=" + projectName + "\n"
+	f, err := os.OpenFile(envPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.WriteString(addition); err != nil {
+		return err
+	}
+	fmt.Printf("Added PROJECT_NAME=%s to %s\n", projectName, filepath.Join(".sandcastle", ".env"))
+	return nil
 }
 
 // remoteProjectPath returns the directory the cron command should `cd` into

--- a/template/builtin/sandcastle_init/env.example
+++ b/template/builtin/sandcastle_init/env.example
@@ -14,3 +14,8 @@ GH_TOKEN=
 
 # Repo to clone for per-run worktrees (HTTPS or SSH URL)
 REPO_URL=
+
+# Project name — pins the agent's cache dir (~/.lazycron-cache/repos/<name>)
+# and the sandcastle Docker image tag. Auto-filled by `lazycron init`; keep
+# in sync with .lazycron/config.yaml's name field if you change it.
+PROJECT_NAME=


### PR DESCRIPTION
## Summary

When you run a sandcastle agent job (e.g. `issue-worker-agent`), the wrong docker image was being used — `sandcastle:lazycron` instead of `sandcastle:<your-project>`. The agent ran against a stale cached lazycron checkout regardless of `REPO_URL`.

**Root cause:** the bundled agent templates fall back to a hard-coded `"lazycron"` when `PROJECT_NAME` isn't set. `ensureRepo` keys its cache dir by that literal (`~/.lazycron-cache/repos/lazycron`), and sandcastle's `defaultImageName(repoDir)` derives the docker tag from the basename of the cache dir. So `cd ~/code/foo && tsx .sandcastle/jobs/x.ts` silently runs inside `sandcastle:lazycron` even when the user built `sandcastle:foo`.

**Fix at the two write points lazycron already owns:**

- `lazycron init --with-agents` pre-fills `PROJECT_NAME=<name>` in `.sandcastle/.env` alongside the existing `REPO_URL` auto-fill.
- `lazycron sync` idempotently appends `PROJECT_NAME=<name>` to `.sandcastle/.env` if it isn't already there — so existing projects pick up the fix on their next sync without re-initing.

The cron command line stays untouched — env vars belong in `.env`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] Fresh `lazycron init --with-agents` writes `PROJECT_NAME=<basename>` to `.sandcastle/.env`
- [ ] Existing project: `lazycron sync` appends `PROJECT_NAME=<name>` once, no-ops on re-run
- [ ] After fix, the running container is `sandcastle:<your-project>`, not `sandcastle:lazycron`