### PR TITLE
refactor: drop .lazycron/ scaffold from `init`, gitignore .sandcastle

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Schedule sandboxed AI agents from your repo. Lazycron pairs with [sandcastle](ht
 lazycron init --with-agents
 ```
 
-This scaffolds `.lazycron/config.yaml` and a sibling `.sandcastle/` (Dockerfile, `.env.example`, `lib/ensureRepo.ts`, plus all bundled agent templates under `jobs/`). Defaults: Claude Code agent, Docker sandbox, GitHub Issues backlog. No prompts, no `npx sandcastle init` call.
+This adds `.sandcastle` to `.gitignore` and scaffolds a `.sandcastle/` directory (Dockerfile, `.env.example`, `lib/ensureRepo.ts`, plus all bundled agent templates under `jobs/`). Defaults: Claude Code agent, Docker sandbox, GitHub Issues backlog. No prompts, no `npx sandcastle init` call.
 
 Apply an agent template:
 
@@ -127,7 +127,7 @@ lazycron sync --no-build             # skip docker build
 lazycron sync --skip-deps-check      # skip docker/node/npx check
 ```
 
-`lazycron sync` checks docker/node/npx on the target, tars `.lazycron/` and `.sandcastle/` over SSH, runs `npm install --prefix .sandcastle` to install pinned `@ai-hero/sandcastle` + `tsx`, then `npx @ai-hero/sandcastle docker build-image` on the target, and installs cron entries that `cd` into the synced project directory before launching each agent via the locally-installed `tsx`.
+`lazycron sync` checks docker/node/npx on the target, tars `.sandcastle/` over SSH, runs `npm install --prefix .sandcastle` to install pinned `@ai-hero/sandcastle` + `tsx`, then `npx @ai-hero/sandcastle docker build-image` on the target, and installs cron entries that `cd` into the synced project directory before launching each agent via the locally-installed `tsx`.
 
 Sync is a **safe merge** — it only adds or updates jobs derived from `.sandcastle/jobs/*.ts`. Existing jobs created through the TUI are never deleted.
 
@@ -157,7 +157,6 @@ Lazycron does **not** execute user TS at sync time — it only reads metadata. S
 
 ```
 my-repo/
-├── .lazycron/config.yaml            # project name (and future per-project config)
 └── .sandcastle/
     ├── Dockerfile, .env, .env.example
     ├── lib/ensureRepo.ts            # bundled helper for clone + fetch
@@ -170,7 +169,7 @@ my-repo/
 
 ```bash
 lazycron                    # launch TUI (default)
-lazycron init               # scaffold .lazycron/ in current dir
+lazycron init               # add .sandcastle to .gitignore
 lazycron init --with-agents # also scaffold .sandcastle/ (Claude Code + Docker + bundled agent templates)
 lazycron list               # list all cron jobs
 lazycron add -n "backup" -s "every day at 3am" -c "pg_dump mydb > /tmp/backup.sql"

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/swalha1999/lazycron/config"
 	"github.com/swalha1999/lazycron/template"
 	"github.com/swalha1999/lazycron/template/builtin"
 )
@@ -20,7 +19,6 @@ import (
 var (
 	initWithAgents bool
 	initName       string
-	initForce      bool
 	// scaffoldSandcastleConfig is a swappable seam so tests can stub the
 	// .sandcastle/ scaffold step.
 	scaffoldSandcastleConfig = realScaffoldSandcastleConfig
@@ -30,17 +28,16 @@ var (
 
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Initialize a lazycron project (.lazycron/ + optional .sandcastle/)",
-	Long: "Scaffolds a .lazycron/config.yaml in the current directory. " +
-		"With --with-agents, also scaffolds a sibling .sandcastle/ directory " +
+	Short: "Initialize a lazycron project (.sandcastle/ scaffold + .gitignore)",
+	Long: "Adds .sandcastle to .gitignore in the current directory. " +
+		"With --with-agents, also scaffolds a .sandcastle/ directory " +
 		"with a Claude Code + Docker + GitHub Issues setup ready for `lazycron sync`.",
 	RunE: runInit,
 }
 
 func init() {
 	initCmd.Flags().BoolVar(&initWithAgents, "with-agents", false, "also scaffold .sandcastle/ (Claude Code, Docker, GitHub Issues)")
-	initCmd.Flags().StringVar(&initName, "name", "", "project name (defaults to current directory's basename)")
-	initCmd.Flags().BoolVar(&initForce, "force", false, "overwrite an existing .lazycron/")
+	initCmd.Flags().StringVar(&initName, "name", "", "project name baked into .sandcastle/.env (defaults to current directory's basename)")
 	rootCmd.AddCommand(initCmd)
 }
 
@@ -50,22 +47,12 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("get cwd: %w", err)
 	}
 
-	lazycronDir := filepath.Join(cwd, ".lazycron")
-	if _, err := os.Stat(lazycronDir); err == nil && !initForce {
-		return fmt.Errorf(".lazycron/ already exists in %s — pass --force to overwrite", cwd)
-	}
-
 	name := initName
 	if name == "" {
 		name = filepath.Base(cwd)
 	}
 
-	if err := config.SaveProjectConfig(lazycronDir, &config.ProjectConfig{Name: name}); err != nil {
-		return fmt.Errorf("write project config: %w", err)
-	}
-	fmt.Printf("Created %s\n", filepath.Join(".lazycron", "config.yaml"))
-
-	if err := appendGitignore(cwd, ".lazycron/.env"); err != nil {
+	if err := appendGitignore(cwd, ".sandcastle"); err != nil {
 		return fmt.Errorf("update .gitignore: %w", err)
 	}
 
@@ -100,10 +87,6 @@ func scaffoldSandcastle(cwd, projectName string) error {
 		return fmt.Errorf("write ensureRepo.ts: %w", err)
 	}
 	fmt.Printf("Created %s\n", filepath.Join(".sandcastle", "lib", "ensureRepo.ts"))
-
-	if err := appendGitignore(cwd, ".sandcastle/.env"); err != nil {
-		return fmt.Errorf("update .gitignore: %w", err)
-	}
 
 	if err := applyAllSandcastleTemplates(cwd); err != nil {
 		return fmt.Errorf("apply sandcastle templates: %w", err)

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -38,14 +38,14 @@ func stubInit(t *testing.T, scaffold func(string, string) error, write func(stri
 
 func resetInitFlags(t *testing.T) {
 	t.Helper()
-	prevAgents, prevName, prevForce := initWithAgents, initName, initForce
-	initWithAgents, initName, initForce = false, "", false
+	prevAgents, prevName := initWithAgents, initName
+	initWithAgents, initName = false, ""
 	t.Cleanup(func() {
-		initWithAgents, initName, initForce = prevAgents, prevName, prevForce
+		initWithAgents, initName = prevAgents, prevName
 	})
 }
 
-func TestRunInit_BasicScaffold(t *testing.T) {
+func TestRunInit_AddsSandcastleToGitignore(t *testing.T) {
 	dir := chdirTemp(t)
 	resetInitFlags(t)
 	initName = "my-proj"
@@ -54,79 +54,33 @@ func TestRunInit_BasicScaffold(t *testing.T) {
 		t.Fatalf("runInit: %v", err)
 	}
 
-	cfgPath := filepath.Join(dir, ".lazycron", "config.yaml")
-	data, err := os.ReadFile(cfgPath)
-	if err != nil {
-		t.Fatalf("read config.yaml: %v", err)
-	}
-	if !strings.Contains(string(data), "name: my-proj") {
-		t.Errorf("expected `name: my-proj` in config, got: %s", string(data))
-	}
-
 	gi, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
 	if err != nil {
 		t.Fatalf("read .gitignore: %v", err)
 	}
-	if !strings.Contains(string(gi), ".lazycron/.env") {
-		t.Errorf("expected .gitignore to include .lazycron/.env, got: %s", string(gi))
+	if !strings.Contains(string(gi), ".sandcastle") {
+		t.Errorf("expected .gitignore to include .sandcastle, got: %s", string(gi))
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, ".lazycron")); !os.IsNotExist(err) {
+		t.Errorf("expected no .lazycron/ to be created, got err=%v", err)
 	}
 }
 
-func TestRunInit_NameDefaultsToBasename(t *testing.T) {
-	// Use a Go-friendly basename so it's not yaml-quoted as a number.
-	parent := t.TempDir()
-	dir := filepath.Join(parent, "myproject")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	prev, _ := os.Getwd()
-	if err := os.Chdir(dir); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(prev) })
+func TestRunInit_IsIdempotent(t *testing.T) {
+	dir := chdirTemp(t)
 	resetInitFlags(t)
 
 	if err := runInit(nil, nil); err != nil {
-		t.Fatalf("runInit: %v", err)
+		t.Fatalf("first runInit: %v", err)
 	}
-
-	data, _ := os.ReadFile(filepath.Join(dir, ".lazycron", "config.yaml"))
-	if !strings.Contains(string(data), "name: myproject") {
-		t.Errorf("expected `name: myproject` in config, got: %s", string(data))
-	}
-}
-
-func TestRunInit_RefuseExisting(t *testing.T) {
-	dir := chdirTemp(t)
-	resetInitFlags(t)
-	if err := os.MkdirAll(filepath.Join(dir, ".lazycron"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	err := runInit(nil, nil)
-	if err == nil || !strings.Contains(err.Error(), "already exists") {
-		t.Fatalf("expected 'already exists' error, got %v", err)
-	}
-}
-
-func TestRunInit_ForceOverwrites(t *testing.T) {
-	dir := chdirTemp(t)
-	resetInitFlags(t)
-	initForce = true
-	initName = "second"
-
-	// Pre-create with a different name.
-	if err := os.MkdirAll(filepath.Join(dir, ".lazycron"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	_ = os.WriteFile(filepath.Join(dir, ".lazycron", "config.yaml"), []byte("name: first\n"), 0o644)
-
 	if err := runInit(nil, nil); err != nil {
-		t.Fatalf("runInit: %v", err)
+		t.Fatalf("second runInit: %v", err)
 	}
-	data, _ := os.ReadFile(filepath.Join(dir, ".lazycron", "config.yaml"))
-	if !strings.Contains(string(data), "name: second") {
-		t.Errorf("expected name: second after --force, got: %s", string(data))
+
+	data, _ := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if got := strings.Count(string(data), ".sandcastle"); got != 1 {
+		t.Errorf("expected .sandcastle to appear exactly once in .gitignore, got %d times", got)
 	}
 }
 
@@ -138,8 +92,6 @@ func TestRunInit_WithAgents_StubbedHooks(t *testing.T) {
 
 	scaffoldCalls := 0
 	writeCalls := 0
-	// Resolve symlinks since macOS /var -> /private/var; t.TempDir uses the
-	// unresolved form but os.Getwd inside runInit returns the resolved one.
 	resolvedDir, _ := filepath.EvalSymlinks(dir)
 	stubInit(t,
 		func(cwd, projectName string) error {
@@ -169,36 +121,35 @@ func TestRunInit_WithAgents_StubbedHooks(t *testing.T) {
 	}
 
 	gi, _ := os.ReadFile(filepath.Join(dir, ".gitignore"))
-	if !strings.Contains(string(gi), ".sandcastle/.env") {
-		t.Errorf("expected .gitignore to include .sandcastle/.env, got: %s", string(gi))
+	if !strings.Contains(string(gi), ".sandcastle") {
+		t.Errorf("expected .gitignore to include .sandcastle, got: %s", string(gi))
 	}
 }
 
 func TestAppendGitignore_Idempotent(t *testing.T) {
 	dir := chdirTemp(t)
 
-	if err := appendGitignore(dir, ".lazycron/.env"); err != nil {
+	if err := appendGitignore(dir, ".sandcastle"); err != nil {
 		t.Fatal(err)
 	}
-	if err := appendGitignore(dir, ".lazycron/.env"); err != nil {
+	if err := appendGitignore(dir, ".sandcastle"); err != nil {
 		t.Fatal(err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, ".gitignore"))
-	if got := strings.Count(string(data), ".lazycron/.env"); got != 1 {
-		t.Errorf("expected .lazycron/.env to appear exactly once, got %d times", got)
+	if got := strings.Count(string(data), ".sandcastle"); got != 1 {
+		t.Errorf("expected .sandcastle to appear exactly once, got %d times", got)
 	}
 }
 
 func TestAppendGitignore_AddsNewlineWhenNeeded(t *testing.T) {
 	dir := chdirTemp(t)
-	// File without trailing newline.
 	_ = os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("node_modules"), 0o644)
 
-	if err := appendGitignore(dir, ".lazycron/.env"); err != nil {
+	if err := appendGitignore(dir, ".sandcastle"); err != nil {
 		t.Fatal(err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, ".gitignore"))
-	want := "node_modules\n.lazycron/.env\n"
+	want := "node_modules\n.sandcastle\n"
 	if string(data) != want {
 		t.Errorf("got %q, want %q", string(data), want)
 	}


### PR DESCRIPTION
## Summary

- `lazycron init` no longer creates `.lazycron/config.yaml`. The project name falls back to the cwd basename via `ResolveProjectName`, which already handled the missing-config case, so sync/diff still work unchanged.
- The single thing `init` always does is now `appendGitignore(cwd, ".sandcastle")`. The redundant `.sandcastle/.env` line written under `--with-agents` is gone — covered by the top-level `.sandcastle` entry.
- Removed the `--force` flag (nothing left to overwrite) and the `.lazycron/`-already-exists guard.
- `--name` still works: under `--with-agents` it pre-fills `PROJECT_NAME=` in `.sandcastle/.env`.

## Why

`.lazycron/config.yaml` only ever stored the project name, and `ResolveProjectName` already falls back to the cwd basename, so the file was paying for itself with directory clutter and an error path. Pushing `.sandcastle` into the project's top-level `.gitignore` unconditionally is also closer to how this user treats the directory in practice.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages pass
- [ ] Manual: run `lazycron init` in a fresh dir → verify `.gitignore` gains `.sandcastle`, no `.lazycron/` is created
- [ ] Manual: run `lazycron init --with-agents` → verify `.sandcastle/` scaffold still produces all expected files
- [ ] Manual: run `lazycron sync` in a project without `.lazycron/config.yaml` → verify project name resolves to cwd basename