### PR TITLE
agents: add cve-scout and bug-scout

### DIFF
--- a/template/builtin/templates/ai/bug-scout.ts
+++ b/template/builtin/templates/ai/bug-scout.ts
@@ -1,0 +1,51 @@
+// description: Weekly bug scout — reads recent code and files ONE issue for a real, reproducible bug
+export const cron = "0 8 * * 3";
+export const name = "Bug Scout";
+export const tag = "BG";
+export const tagColor = "#fab387";
+
+import { run, claudeCode } from "@ai-hero/sandcastle";
+import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+import { ensureRepo, requireEnv, agentSandboxConfig } from "../lib/ensureRepo";
+
+requireEnv("REPO_URL", "GH_TOKEN");
+
+const repoDir = ensureRepo({
+  url: process.env.REPO_URL!,
+  name: process.env.PROJECT_NAME ?? "lazycron",
+  defaultBranch: process.env.BASE_BRANCH ?? "main",
+});
+process.chdir(repoDir);
+
+const branch = `bug-scout-${Date.now()}`;
+
+const result = await run({
+  name: "bug-scout",
+  agent: claudeCode("claude-opus-4-7"),
+  sandbox: docker(agentSandboxConfig()),
+  branchStrategy: { type: "branch", branch },
+  prompt: `You are a bug scout. Read the codebase and file ONE issue describing a real, concrete bug. Do NOT modify code. Do NOT open a PR.
+
+You are looking for actual defects, not style. Good candidates:
+- Wrong control flow: off-by-one, inverted boolean, missing return, unreachable branch
+- Unhandled error paths: ignored \`err\`, swallowed exceptions, missing rollback on partial failure
+- Concurrency hazards: shared mutable state, missing lock/await, data race, leaked goroutine/promise
+- Resource leaks: unclosed file/connection/timer, missing \`defer\` / \`finally\`
+- Incorrect input validation: trust boundary violations, integer overflow, path traversal, command injection
+- Logic that contradicts the surrounding comment, docstring, or test expectation
+
+Skip: refactor opportunities, style nits, "could be simpler", anything you can't pin to a file:line with a concrete failure scenario.
+
+Process:
+1. Skim the recent diff: \`git log --oneline -50\` then \`git diff HEAD~20 HEAD -- <changed paths>\` for the hottest files.
+2. Read those files end-to-end (not just the diff) — bugs often live in the unchanged neighbor.
+3. For each candidate, write down: input that triggers it → expected behaviour → actual behaviour. If you can't fill all three, it isn't ready to file.
+4. Pick the single highest-impact bug. Check existing open issues with the \`bug\` label — do not duplicate.
+5. File the issue:
+   \`gh issue create --label bug --title "<concise symptom>" --body "<location (file:line) / trigger / expected vs actual / why this is wrong / suggested fix direction>\\n\\nAuto by Lazycron agent."\`
+
+If nothing meets the "real defect with a concrete trigger" bar, STAND DOWN and exit cleanly.`,
+  maxIterations: 1,
+});
+
+console.log(`Bug scout finished: ${result.commits.length === 0 ? "no commits (expected — scout doesn't modify code)" : "unexpected commits, check the run"}.`);

--- a/template/builtin/templates/ai/bug-scout.ts
+++ b/template/builtin/templates/ai/bug-scout.ts
@@ -28,10 +28,13 @@ const result = await run({
 
 You are looking for actual defects, not style. Good candidates:
 - Wrong control flow: off-by-one, inverted boolean, missing return, unreachable branch
+- Wrong logic or implementation: the code does X but the spec / comment / call site clearly expects Y; an algorithm that returns the wrong result on a realistic input
+- Broken or missing authorization: an endpoint / handler / RPC that trusts the caller, skips an ownership check, mixes up "authenticated" with "authorized", IDOR (one user can act on another user's resource), missing role/tenant check, auth check on the client only
+- Data leakage to the UI / API response: serializing a whole DB row when only a subset is meant to be public (password hashes, tokens, internal IDs, other users' data, soft-deleted rows, draft/private records), returning stack traces or internal error messages to end users, debug logs that include secrets / PII, over-broad SELECT * crossing a trust boundary
 - Unhandled error paths: ignored \`err\`, swallowed exceptions, missing rollback on partial failure
 - Concurrency hazards: shared mutable state, missing lock/await, data race, leaked goroutine/promise
 - Resource leaks: unclosed file/connection/timer, missing \`defer\` / \`finally\`
-- Incorrect input validation: trust boundary violations, integer overflow, path traversal, command injection
+- Incorrect input validation: trust boundary violations, integer overflow, path traversal, command injection, SSRF
 - Logic that contradicts the surrounding comment, docstring, or test expectation
 
 Skip: refactor opportunities, style nits, "could be simpler", anything you can't pin to a file:line with a concrete failure scenario.
@@ -39,7 +42,8 @@ Skip: refactor opportunities, style nits, "could be simpler", anything you can't
 Process:
 1. Skim the recent diff: \`git log --oneline -50\` then \`git diff HEAD~20 HEAD -- <changed paths>\` for the hottest files.
 2. Read those files end-to-end (not just the diff) — bugs often live in the unchanged neighbor.
-3. For each candidate, write down: input that triggers it → expected behaviour → actual behaviour. If you can't fill all three, it isn't ready to file.
+3. Trace at least one request/handler from entry point to response: who is the caller, what auth/ownership check runs, what gets returned. Auth and data-leak bugs only surface when you follow the full path.
+4. For each candidate, write down: input (and which user/role) that triggers it → expected behaviour → actual behaviour. If you can't fill all three, it isn't ready to file.
 4. Pick the single highest-impact bug. Check existing open issues with the \`bug\` label — do not duplicate.
 5. File the issue:
    \`gh issue create --label bug --title "<concise symptom>" --body "<location (file:line) / trigger / expected vs actual / why this is wrong / suggested fix direction>\\n\\nAuto by Lazycron agent."\`

--- a/template/builtin/templates/ai/cve-scout.ts
+++ b/template/builtin/templates/ai/cve-scout.ts
@@ -1,0 +1,47 @@
+// description: Daily CVE scout — checks dependencies against latest advisories and files ONE issue if the project is vulnerable
+export const cron = "0 7 * * *";
+export const name = "CVE Scout";
+export const tag = "CV";
+export const tagColor = "#f9e2af";
+
+import { run, claudeCode } from "@ai-hero/sandcastle";
+import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+import { ensureRepo, requireEnv, agentSandboxConfig } from "../lib/ensureRepo";
+
+requireEnv("REPO_URL", "GH_TOKEN");
+
+const repoDir = ensureRepo({
+  url: process.env.REPO_URL!,
+  name: process.env.PROJECT_NAME ?? "lazycron",
+  defaultBranch: process.env.BASE_BRANCH ?? "main",
+});
+process.chdir(repoDir);
+
+const branch = `cve-scout-${Date.now()}`;
+
+const result = await run({
+  name: "cve-scout",
+  agent: claudeCode("claude-opus-4-7"),
+  sandbox: docker(agentSandboxConfig()),
+  branchStrategy: { type: "branch", branch },
+  prompt: `You are a CVE scout. Check whether this project is exposed to any KNOWN, CURRENT security vulnerabilities and file ONE issue for the most serious finding. Do NOT modify code. Do NOT open a PR.
+
+Process:
+1. Identify the dependency manifests in the repo (e.g. \`package.json\`, \`package-lock.json\`, \`go.mod\`, \`go.sum\`, \`requirements.txt\`, \`Cargo.lock\`, \`pnpm-lock.yaml\`). Read the actual versions, not just the ranges.
+2. Run native auditors when available and capture their output:
+   - Node:   \`npm audit --json\` or \`pnpm audit --json\`
+   - Go:     \`govulncheck ./...\` (skip silently if not installed)
+   - Python: \`pip-audit -f json\` (skip silently if not installed)
+3. Cross-check with the GitHub Advisory Database via \`gh api graphql\` for the top 3 direct dependencies if the auditors found nothing notable.
+4. Rank findings by severity (CRITICAL > HIGH > MEDIUM), then by exploitability (is the vulnerable code path actually reached?).
+5. Check existing open issues with the \`security\` label — do not duplicate.
+6. File ONE issue for the single highest-impact, confirmed vulnerability:
+   \`gh issue create --label security --title "<CVE-ID or advisory>: <package>@<version>" --body "<severity / affected version / fixed version / where it's used in this repo (file:line) / suggested upgrade>\\n\\nAuto by Lazycron agent."\`
+
+Skip: theoretical issues, dev-only deps with no production impact, advisories already fixed in the version range we resolve to, anything without a clear remediation path.
+
+If nothing rises to "this is a real exposure," STAND DOWN and exit cleanly.`,
+  maxIterations: 1,
+});
+
+console.log(`CVE scout finished: ${result.commits.length === 0 ? "no commits (expected — scout doesn't modify code)" : "unexpected commits, check the run"}.`);


### PR DESCRIPTION
## Summary
Two new scouts that follow the same contract as `audit-agents` (file ONE issue, never modify code) so `worker-agent` can drain them:

- **cve-scout** (daily 07:00) — runs `npm audit` / `govulncheck` / `pip-audit` against actual lockfile versions, cross-checks the GitHub Advisory DB, files one issue for the most serious real exposure. Skips theoretical / already-fixed / dev-only findings. Labels with `security`.
- **bug-scout** (weekly Wed 08:00) — reads recent diffs plus neighboring code, only files when it can pin a defect to file:line with a concrete input → expected → actual scenario. Skips style/refactor. Labels with `bug`.

Together with #98 the bundle is now: audit (cleanup) + bug + cve as backlog producers, worker as the consumer.

## Test plan
- [x] `go test ./...` green
- [ ] `lazycron init --with-agents` in a scratch dir scaffolds the four scouts + worker